### PR TITLE
feat: build public wiki browsing experience

### DIFF
--- a/apps/core/management/commands/seed_wiki.py
+++ b/apps/core/management/commands/seed_wiki.py
@@ -283,8 +283,16 @@ confidence = \frac{verified\_sources}{all\_claims}
 class Command(BaseCommand):
     help = "Seed local wiki data into the current database."
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--with-mock-embeddings",
+            action="store_true",
+            help="Seed deterministic mock embeddings for local testing.",
+        )
+
     @transaction.atomic
     def handle(self, *args, **options):
+        use_mock_embeddings = options["with_mock_embeddings"]
         seeded_documents = 0
         seeded_revisions = 0
         seeded_sources = 0
@@ -327,16 +335,17 @@ class Command(BaseCommand):
                 )
                 chunk_instances.append(chunk)
 
-                ChunkEmbedding.objects.update_or_create(
-                    source_chunk=chunk,
-                    embedding_model=EMBEDDING_MODEL,
-                    defaults={
-                        "embedding_dim": EMBEDDING_DIM,
-                        "embedding": self._build_embedding(chunk.chunk_index),
-                        "content_hash": self._content_hash(chunk.content_text),
-                    },
-                )
-                seeded_embeddings += 1
+                if use_mock_embeddings:
+                    ChunkEmbedding.objects.update_or_create(
+                        source_chunk=chunk,
+                        embedding_model=EMBEDDING_MODEL,
+                        defaults={
+                            "embedding_dim": EMBEDDING_DIM,
+                            "embedding": self._build_embedding(chunk.chunk_index),
+                            "content_hash": self._content_hash(chunk.content_text),
+                        },
+                    )
+                    seeded_embeddings += 1
 
             wiki_document, created = WikiDocument.objects.update_or_create(
                 slug=seed["wiki"]["slug"],
@@ -391,6 +400,13 @@ class Command(BaseCommand):
                 f"{seeded_embeddings} embeddings."
             )
         )
+        if not use_mock_embeddings:
+            self.stdout.write(
+                self.style.WARNING(
+                    "Mock embeddings were skipped. Re-run with "
+                    "--with-mock-embeddings if you need deterministic local vectors."
+                )
+            )
 
     def _build_embedding(self, seed_value):
         base = seed_value + 1

--- a/apps/core/management/commands/seed_wiki.py
+++ b/apps/core/management/commands/seed_wiki.py
@@ -1,0 +1,402 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils import timezone
+
+from apps.core.models import (
+    ChunkEmbedding,
+    Source,
+    SourceChunk,
+    SourceDocument,
+    SourceDocumentFetchStatus,
+    SourceDocumentWikiStatus,
+    WikiDocument,
+    WikiDocumentStatus,
+    WikiGenerationType,
+    WikiRevision,
+    WikiRevisionSource,
+)
+
+EMBEDDING_MODEL = "text-embedding-3-small"
+EMBEDDING_DIM = 1536
+
+SEED_DOCUMENTS = [
+    {
+        "source": {
+            "name": "HiveWiki Seed Source",
+            "target_url": "https://local.hivewiki.test/wiki-seed",
+        },
+        "document": {
+            "canonical_url": "https://local.hivewiki.test/docs/capstone-wiki-guide",
+            "title": "캡스톤 위키 운영 가이드",
+            "body_text": (
+                "캡스톤 팀이 문서를 수집하고, 검토하고, 위키 문서로 승격하는 "
+                "운영 흐름을 정리한 기준 문서입니다."
+            ),
+        },
+        "chunks": [
+            {
+                "chunk_index": 0,
+                "chunk_type": "intro",
+                "section_title": "문서 수집 원칙",
+                "content_text": (
+                    "질문, 회고, 운영 기록 중 반복 활용 가치가 높은 항목을 "
+                    "우선적으로 수집해 source chunk로 보관합니다."
+                ),
+            },
+            {
+                "chunk_index": 1,
+                "chunk_type": "policy",
+                "section_title": "위키 승격 기준",
+                "content_text": (
+                    "두 번 이상 반복된 질문이거나 팀 온보딩에 직접 도움이 되는 "
+                    "내용은 위키 문서로 승격합니다."
+                ),
+            },
+            {
+                "chunk_index": 2,
+                "chunk_type": "workflow",
+                "section_title": "운영 루프",
+                "content_text": (
+                    "수집, 초안 작성, 검토, 게시, 후속 업데이트로 이어지는 "
+                    "반복 운영 루프를 정의해 문서 품질을 유지합니다."
+                ),
+            },
+            {
+                "chunk_index": 3,
+                "chunk_type": "ownership",
+                "section_title": "관리 책임",
+                "content_text": (
+                    "문서 소유자와 리뷰어를 분리해 장기 유지보수 책임을 "
+                    "명확히 하고, 갱신 주기를 운영 기준에 포함합니다."
+                ),
+            },
+        ],
+        "wiki": {
+            "title": "캡스톤 위키 운영 가이드",
+            "slug": "capstone-wiki-guide",
+            "summary": ("문서 수집, 검토, 승격 절차를 정리한 기본 운영 문서입니다."),
+            "content_markdown": """# 캡스톤 위키 운영 가이드
+
+## 문서 수집 원칙
+- 반복되는 질문과 답변을 우선 수집합니다.
+- 운영 회고와 정책 변경 사항을 source chunk로 저장합니다.
+- 논의 당시의 맥락이 사라지지 않도록 결정 배경을 함께 기록합니다.
+
+문서 수집 단계에서는 "나중에 다시 설명해야 하는가"를 가장 중요한 판단 기준으로 삼습니다.
+한 번의 답변으로 끝나는 내용보다, 새 팀원이 같은 질문을 반복할 가능성이 있는 주제를 먼저 쌓는 편이
+위키의 효율을 높입니다.
+
+## 위키 승격 기준
+- 온보딩 효율을 높이는 정보
+- 두 번 이상 반복된 질문
+- 팀의 공식 기준으로 삼을 수 있는 내용
+
+질문의 빈도만으로 승격 여부를 결정하지는 않습니다.
+답변이 어느 정도 안정되어 있는지, 팀의 현재 합의와 충돌하지 않는지,
+그리고 이후 운영 과정에서 참조 포인트로 쓰일 수 있는지를 함께 봐야 합니다.
+
+## 운영 루프
+1. 커뮤니티나 회고에서 후보 내용을 모읍니다.
+2. source chunk 단위로 쪼개고 제목과 맥락을 정리합니다.
+3. 위키 초안을 만든 뒤 출처와 연결합니다.
+4. 검토가 끝나면 published 상태로 공개합니다.
+5. 후속 피드백을 받아 revision을 갱신합니다.
+
+운영 루프는 한 번 쓰고 끝나는 문서보다, 자주 갱신되는 문서에서 특히 중요합니다.
+실제 사용자가 보고 있는 문서가 최신 판단 기준을 반영하는지 주기적으로 확인해야 합니다.
+
+## 관리 책임
+각 문서에는 최소한 한 명의 관리 책임자가 있어야 합니다.
+책임자는 문서가 낡았는지 점검하고, 필요할 경우 revision을 추가하며,
+관련 커뮤니티 스레드나 운영 공지를 다시 연결하는 역할을 맡습니다.
+
+리뷰어는 표현을 다듬는 사람이라기보다, 문서가 현재 운영 기준과 맞는지를 확인하는 사람에 가깝습니다.
+이 구분이 없으면 위키는 초안은 많고 신뢰할 수 있는 문서는 적은 상태가 되기 쉽습니다.
+""",
+        },
+    },
+    {
+        "source": {
+            "name": "HiveWiki Seed Source",
+            "target_url": "https://local.hivewiki.test/wiki-seed",
+        },
+        "document": {
+            "canonical_url": "https://local.hivewiki.test/docs/community-to-wiki",
+            "title": "커뮤니티 질문을 위키로 전환하는 기준",
+            "body_text": (
+                "커뮤니티에서 나온 질문과 답변을 어떤 기준으로 구조화해 "
+                "위키 문서로 만드는지 정리한 문서입니다."
+            ),
+        },
+        "chunks": [
+            {
+                "chunk_index": 0,
+                "chunk_type": "criteria",
+                "section_title": "선정 기준",
+                "content_text": (
+                    "질문 빈도, 답변의 안정성, 장기 보존 가치가 높은 항목부터 "
+                    "위키 후보로 분류합니다."
+                ),
+            },
+            {
+                "chunk_index": 1,
+                "chunk_type": "workflow",
+                "section_title": "편집 흐름",
+                "content_text": (
+                    "초안 생성 후 출처 chunk를 연결하고, 요약과 제목을 다듬은 뒤 "
+                    "current revision으로 반영합니다."
+                ),
+            },
+            {
+                "chunk_index": 2,
+                "chunk_type": "quality",
+                "section_title": "품질 점검",
+                "content_text": (
+                    "질문을 문서로 옮길 때는 단일 답변을 복붙하지 말고, "
+                    "의견 차이와 확정된 기준을 구분해서 편집합니다."
+                ),
+            },
+            {
+                "chunk_index": 3,
+                "chunk_type": "maintenance",
+                "section_title": "후속 관리",
+                "content_text": (
+                    "게시 후에도 관련 질문이 다시 나오면 revision을 갱신하고, "
+                    "오래된 절차는 archived 후보로 분리합니다."
+                ),
+            },
+        ],
+        "wiki": {
+            "title": "커뮤니티 질문을 위키로 전환하는 기준",
+            "slug": "community-to-wiki-criteria",
+            "summary": ("질문, 답변, 회고를 위키 문서로 구조화하는 판단 기준입니다."),
+            "content_markdown": """# 커뮤니티 질문을 위키로 전환하는 기준
+
+## 선정 기준
+- 반복 빈도가 높은 질문
+- 답변의 일관성이 확보된 주제
+- 나중에도 참조될 운영 지식
+
+커뮤니티에 올라오는 모든 질문을 곧바로 위키로 옮기면 위키는 금방 잡음이 많아집니다.
+질문의 반복 빈도, 답변의 안정성, 이후 온보딩과 운영에 다시 쓰일 가능성을 함께 고려해야
+읽을 가치가 있는 문서가 남습니다.
+
+특히 답변이 사람마다 다른 상태라면, 그 질문은 아직 위키 문서보다 토론 스레드에 가까울 수 있습니다.
+이때는 문서를 만들기보다 "현재 확인된 사실"과 "열린 이슈"를 분리한 임시 초안이 더 적합합니다.
+
+## 편집 흐름
+1. 관련 chunk를 모읍니다.
+2. 초안 문서를 작성합니다.
+3. revision source를 연결합니다.
+4. current revision을 갱신합니다.
+
+편집자는 질문 자체를 그대로 옮기기보다, 나중에 다시 찾을 사람이 어떤 제목으로 검색할지를 먼저 생각해야 합니다.
+문서 제목은 질문 문장을 그대로 쓰는 것보다, 해결하려는 주제나 판단 기준을 드러내는 쪽이 검색과 유지보수에 유리합니다.
+
+## 품질 점검
+문서를 게시하기 전에는 최소한 세 가지를 확인합니다.
+
+1. 문서의 결론이 현재 운영 기준과 충돌하지 않는가
+2. 출처로 연결된 chunk가 실제 본문 주장을 뒷받침하는가
+3. 제목과 summary만 읽어도 문서의 용도가 명확한가
+
+품질 점검 단계에서 자주 발견되는 문제는 "질문은 분명한데 답변이 너무 길거나, 반대로 결론은 있는데 근거가 약한 경우"입니다.
+이럴 때는 문서를 더 길게 쓰기보다, 결론과 근거를 분리해 구조를 다시 잡는 편이 낫습니다.
+
+## 마크다운 예시
+다음은 위키 문서에서 자주 쓰는 구성 요소를 한 번에 점검하기 위한 예시입니다.
+
+> 위키는 단순 저장소가 아니라, 팀의 현재 판단 기준을 읽기 좋은 형태로 유지하는 편집 산출물입니다.
+
+인라인 코드 예시로는 `current_revision`, `source_chunk`, `published` 같은 용어가 자주 등장합니다.
+
+### 체크리스트
+- [x] 관련 질문 링크를 모았습니다.
+- [x] 핵심 근거가 되는 chunk를 연결했습니다.
+- [ ] 운영자 리뷰를 반영했습니다.
+- [ ] 후속 revision 필요 여부를 확인했습니다.
+
+### 중첩 리스트
+1. 초안 작성
+   - 질문 배경 정리
+   - 결론 우선 서술
+   - 근거 chunk 연결
+2. 리뷰
+   - 현재 정책과 충돌 여부 확인
+   - 검색 키워드 관점에서 제목 점검
+
+### 표
+| 항목 | 확인 질문 | 실패 시 조치 |
+| --- | --- | --- |
+| 제목 | 검색 의도가 드러나는가 | 주제 중심으로 다시 작성 |
+| 요약 | 3줄 안에 용도가 설명되는가 | 결론 문장을 앞에 배치 |
+| 근거 | 출처 chunk와 연결되는가 | revision source 재정리 |
+
+### 코드 블록
+```python
+def promote_question_to_wiki(question, chunks):
+    if question.repeat_count < 2:
+        return "keep_in_community"
+    if not chunks:
+        return "needs_sources"
+    return "ready_for_revision"
+```
+
+```json
+{
+  "title": "커뮤니티 질문을 위키로 전환하는 기준",
+  "status": "published",
+  "source_count": 4
+}
+```
+
+### 수식
+간단한 점수 예시는 $score = \frac{evidence \times clarity}{maintenance + 1}$ 처럼 표현할 수 있습니다.
+
+블록 수식은 다음처럼 둘 수 있습니다.
+
+$$
+priority(q) = \sum_{i=1}^{n} w_i \cdot signal_i(q)
+$$
+
+또는
+
+\[
+confidence = \frac{verified\_sources}{all\_claims}
+\]
+
+---
+
+## 후속 관리
+위키는 게시 순간보다 게시 이후가 더 중요합니다.
+같은 질문이 다시 들어오면 문서 링크가 실제로 문제를 해결했는지 확인하고,
+설명이 부족했다면 revision을 추가해 최신 사례와 표현을 반영합니다.
+
+반대로 더 이상 쓰이지 않는 절차나 이미 폐기된 정책은 archived 후보로 분리해
+검색 결과에서 현재 문서와 섞이지 않도록 관리해야 합니다.
+""",
+        },
+    },
+]
+
+
+class Command(BaseCommand):
+    help = "Seed local wiki data into the current database."
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        seeded_documents = 0
+        seeded_revisions = 0
+        seeded_sources = 0
+        seeded_embeddings = 0
+
+        for seed in SEED_DOCUMENTS:
+            source, _ = Source.objects.update_or_create(
+                target_url=seed["source"]["target_url"],
+                defaults={
+                    "name": seed["source"]["name"],
+                    "enabled": True,
+                    "updated_at": timezone.now(),
+                },
+            )
+
+            source_document, _ = SourceDocument.objects.update_or_create(
+                source=source,
+                canonical_url=seed["document"]["canonical_url"],
+                defaults={
+                    "title": seed["document"]["title"],
+                    "body_text": seed["document"]["body_text"],
+                    "fetch_status": SourceDocumentFetchStatus.FETCHED,
+                    "wiki_status": SourceDocumentWikiStatus.COMPLETED,
+                },
+            )
+
+            chunk_instances = []
+            for chunk_seed in seed["chunks"]:
+                chunk, _ = SourceChunk.objects.update_or_create(
+                    source_document=source_document,
+                    chunk_index=chunk_seed["chunk_index"],
+                    defaults={
+                        "chunk_type": chunk_seed["chunk_type"],
+                        "section_title": chunk_seed["section_title"],
+                        "content_text": chunk_seed["content_text"],
+                        "token_count": len(chunk_seed["content_text"].split()),
+                        "char_start": 0,
+                        "char_end": len(chunk_seed["content_text"]),
+                    },
+                )
+                chunk_instances.append(chunk)
+
+                ChunkEmbedding.objects.update_or_create(
+                    source_chunk=chunk,
+                    embedding_model=EMBEDDING_MODEL,
+                    defaults={
+                        "embedding_dim": EMBEDDING_DIM,
+                        "embedding": self._build_embedding(chunk.chunk_index),
+                        "content_hash": self._content_hash(chunk.content_text),
+                    },
+                )
+                seeded_embeddings += 1
+
+            wiki_document, created = WikiDocument.objects.update_or_create(
+                slug=seed["wiki"]["slug"],
+                defaults={
+                    "title": seed["wiki"]["title"],
+                    "summary": seed["wiki"]["summary"],
+                    "status": WikiDocumentStatus.PUBLISHED,
+                    "updated_at": timezone.now(),
+                },
+            )
+            seeded_documents += 1
+            if created:
+                self.stdout.write(
+                    self.style.SUCCESS(f"Created wiki document {wiki_document.slug}")
+                )
+
+            revision, _ = WikiRevision.objects.update_or_create(
+                wiki_document=wiki_document,
+                revision_number=1,
+                defaults={
+                    "content_markdown": seed["wiki"]["content_markdown"],
+                    "generation_type": WikiGenerationType.AI,
+                    "generation_model": "gpt-5.5",
+                },
+            )
+            seeded_revisions += 1
+
+            wiki_document.current_revision = revision
+            wiki_document.save(update_fields=["current_revision", "updated_at"])
+
+            existing_source_links = set(
+                WikiRevisionSource.objects.filter(wiki_revision=revision).values_list(
+                    "source_chunk_id", flat=True
+                )
+            )
+            for chunk in chunk_instances:
+                if chunk.id in existing_source_links:
+                    continue
+                WikiRevisionSource.objects.create(
+                    wiki_revision=revision,
+                    source_chunk=chunk,
+                    evidence_text=chunk.content_text[:240],
+                )
+                seeded_sources += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Seed complete: "
+                f"{seeded_documents} wiki documents, "
+                f"{seeded_revisions} revisions, "
+                f"{seeded_sources} revision sources, "
+                f"{seeded_embeddings} embeddings."
+            )
+        )
+
+    def _build_embedding(self, seed_value):
+        base = seed_value + 1
+        return [round(base / 1000, 6)] * EMBEDDING_DIM
+
+    def _content_hash(self, content):
+        import hashlib
+
+        return hashlib.sha256(content.encode("utf-8")).hexdigest()

--- a/apps/core/markdown_rendering.py
+++ b/apps/core/markdown_rendering.py
@@ -1,0 +1,126 @@
+import bleach
+import markdown
+from django.core.cache import cache
+
+from apps.core.wiki_markdown import (
+    annotate_toc_items,
+    build_markdown_context,
+    strip_leading_title_heading,
+)
+
+ALLOWED_TAGS = [
+    "a",
+    "blockquote",
+    "br",
+    "code",
+    "div",
+    "em",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "hr",
+    "input",
+    "li",
+    "ol",
+    "p",
+    "pre",
+    "span",
+    "strong",
+    "table",
+    "tbody",
+    "td",
+    "th",
+    "thead",
+    "tr",
+    "ul",
+]
+ALLOWED_ATTRIBUTES = {
+    "*": ["class", "id"],
+    "a": ["href", "title", "rel"],
+    "div": ["class"],
+    "span": ["class"],
+    "code": ["class"],
+    "pre": ["class"],
+    "input": ["checked", "disabled", "type"],
+}
+REVISION_RENDER_CACHE_TIMEOUT = 60 * 60 * 24 * 7
+
+
+def build_rendered_markdown(
+    markdown_text: str,
+) -> tuple[str, list[dict[str, str | int]]]:
+    if not markdown_text:
+        return "", []
+
+    processed_markdown, toc_items = build_markdown_context(markdown_text)
+    rendered = markdown.markdown(
+        processed_markdown,
+        extensions=[
+            "markdown.extensions.attr_list",
+            "markdown.extensions.codehilite",
+            "markdown.extensions.extra",
+            "markdown.extensions.nl2br",
+            "markdown.extensions.sane_lists",
+            "pymdownx.arithmatex",
+            "pymdownx.tasklist",
+        ],
+        extension_configs={
+            "markdown.extensions.codehilite": {
+                "guess_lang": False,
+                "noclasses": False,
+                "pygments_style": "monokai",
+            },
+            "pymdownx.arithmatex": {"generic": True},
+            "pymdownx.tasklist": {"clickable_checkbox": False},
+        },
+        output_format="html5",
+    )
+    sanitized = bleach.clean(
+        rendered,
+        tags=ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRIBUTES,
+        strip=False,
+    )
+    linked = bleach.linkify(
+        sanitized,
+        callbacks=[_set_link_rel],
+        skip_tags=["pre", "code"],
+        parse_email=False,
+    )
+    return linked, annotate_toc_items(toc_items)
+
+
+def get_cached_revision_render(*, revision, title: str) -> dict[str, object]:
+    if revision is None:
+        return {
+            "display_markdown": "",
+            "rendered_markdown": "",
+            "toc_items": [],
+        }
+
+    cache_key = f"wiki_revision_render:{revision.pk}"
+    cached_value = cache.get(cache_key)
+    if cached_value is not None:
+        return cached_value
+
+    display_markdown = strip_leading_title_heading(revision.content_markdown, title)
+    rendered_markdown, toc_items = build_rendered_markdown(display_markdown)
+    payload = {
+        "display_markdown": display_markdown,
+        "rendered_markdown": rendered_markdown,
+        "toc_items": toc_items,
+    }
+    cache.set(cache_key, payload, REVISION_RENDER_CACHE_TIMEOUT)
+    return payload
+
+
+def _set_link_rel(attrs, new=False):
+    href_key = (None, "href")
+    if href_key not in attrs:
+        return attrs
+
+    attrs[(None, "rel")] = "noopener noreferrer"
+    return attrs

--- a/apps/core/markdown_rendering.py
+++ b/apps/core/markdown_rendering.py
@@ -1,3 +1,5 @@
+import re
+
 import bleach
 import markdown
 from django.core.cache import cache
@@ -47,6 +49,7 @@ ALLOWED_ATTRIBUTES = {
     "input": ["checked", "disabled", "type"],
 }
 REVISION_RENDER_CACHE_TIMEOUT = 60 * 60 * 24 * 7
+CODE_NODE_RE = re.compile(r"<code\b[^>]*>.*?</code>", re.DOTALL)
 
 
 def build_rendered_markdown(
@@ -90,7 +93,7 @@ def build_rendered_markdown(
         skip_tags=["pre", "code"],
         parse_email=False,
     )
-    return linked, annotate_toc_items(toc_items)
+    return _restore_code_entities(linked), annotate_toc_items(toc_items)
 
 
 def get_cached_revision_render(*, revision, title: str) -> dict[str, object]:
@@ -124,3 +127,18 @@ def _set_link_rel(attrs, new=False):
 
     attrs[(None, "rel")] = "noopener noreferrer"
     return attrs
+
+
+def _restore_code_entities(rendered_html: str) -> str:
+    return CODE_NODE_RE.sub(_restore_code_node_entities, rendered_html)
+
+
+def _restore_code_node_entities(match: re.Match[str]) -> str:
+    code_html = match.group(0)
+    return (
+        code_html.replace("&amp;lt;", "&lt;")
+        .replace("&amp;gt;", "&gt;")
+        .replace("&amp;quot;", "&quot;")
+        .replace("&amp;#39;", "&#39;")
+        .replace("&amp;amp;", "&amp;")
+    )

--- a/apps/core/migrations/0002_wiki_models.py
+++ b/apps/core/migrations/0002_wiki_models.py
@@ -1,0 +1,218 @@
+import uuid
+
+import django.db.models.deletion
+import django.utils.timezone
+from django.contrib.postgres.operations import CreateExtension
+from django.db import migrations, models
+
+import apps.core.models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0001_initial"),
+    ]
+
+    operations = [
+        CreateExtension("vector"),
+        migrations.RunSQL(
+            sql=(
+                "CREATE TYPE wiki_document_status AS ENUM "
+                "('published', 'archived', 'deleted');"
+            ),
+            reverse_sql="DROP TYPE wiki_document_status;",
+        ),
+        migrations.RunSQL(
+            sql="CREATE TYPE wiki_generation_type AS ENUM ('ai', 'human');",
+            reverse_sql="DROP TYPE wiki_generation_type;",
+        ),
+        migrations.CreateModel(
+            name="ChunkEmbedding",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("embedding_model", models.CharField(max_length=100)),
+                ("embedding_dim", models.IntegerField()),
+                ("embedding", apps.core.models.VectorField(dimensions=1536)),
+                (
+                    "content_hash",
+                    models.CharField(blank=True, max_length=64, null=True),
+                ),
+                (
+                    "created_at",
+                    models.DateTimeField(
+                        default=django.utils.timezone.now, editable=False
+                    ),
+                ),
+                (
+                    "source_chunk",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="embeddings",
+                        to="core.sourcechunk",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "chunk_embeddings",
+            },
+        ),
+        migrations.CreateModel(
+            name="WikiDocument",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("title", models.CharField(max_length=255)),
+                ("slug", models.CharField(max_length=255, unique=True)),
+                ("summary", models.TextField()),
+                (
+                    "status",
+                    apps.core.models.PostgresEnumField(
+                        choices=[
+                            ("published", "Published"),
+                            ("archived", "Archived"),
+                            ("deleted", "Deleted"),
+                        ],
+                        default="published",
+                        enum_type="wiki_document_status",
+                        max_length=20,
+                    ),
+                ),
+                (
+                    "created_at",
+                    models.DateTimeField(
+                        default=django.utils.timezone.now, editable=False
+                    ),
+                ),
+                ("updated_at", models.DateTimeField(default=django.utils.timezone.now)),
+            ],
+            options={
+                "db_table": "wiki_documents",
+            },
+        ),
+        migrations.CreateModel(
+            name="WikiRevision",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("revision_number", models.IntegerField()),
+                ("content_markdown", models.TextField()),
+                (
+                    "generation_type",
+                    apps.core.models.PostgresEnumField(
+                        choices=[("ai", "AI"), ("human", "Human")],
+                        default="ai",
+                        enum_type="wiki_generation_type",
+                        max_length=20,
+                    ),
+                ),
+                (
+                    "generation_model",
+                    models.CharField(blank=True, max_length=100, null=True),
+                ),
+                (
+                    "created_at",
+                    models.DateTimeField(
+                        default=django.utils.timezone.now, editable=False
+                    ),
+                ),
+                (
+                    "wiki_document",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="revisions",
+                        to="core.wikidocument",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "wiki_revisions",
+            },
+        ),
+        migrations.CreateModel(
+            name="WikiRevisionSource",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("evidence_text", models.TextField(blank=True, null=True)),
+                (
+                    "created_at",
+                    models.DateTimeField(
+                        default=django.utils.timezone.now, editable=False
+                    ),
+                ),
+                (
+                    "source_chunk",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.RESTRICT,
+                        related_name="wiki_revision_sources",
+                        to="core.sourcechunk",
+                    ),
+                ),
+                (
+                    "wiki_revision",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="sources",
+                        to="core.wikirevision",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "wiki_revision_sources",
+            },
+        ),
+        migrations.AddField(
+            model_name="wikidocument",
+            name="current_revision",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="core.wikirevision",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="chunkembedding",
+            constraint=models.UniqueConstraint(
+                fields=("source_chunk", "embedding_model"),
+                name="uq_chunk_embeddings_source_chunk_model",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="wikirevision",
+            constraint=models.UniqueConstraint(
+                fields=("wiki_document", "revision_number"),
+                name="uq_wiki_revisions_document_revision",
+            ),
+        ),
+    ]

--- a/apps/core/models.py
+++ b/apps/core/models.py
@@ -29,6 +29,57 @@ class SourceDocumentWikiStatus(models.TextChoices):
     FAILED = "FAILED", "Failed"
 
 
+class WikiDocumentStatus(models.TextChoices):
+    PUBLISHED = "published", "Published"
+    ARCHIVED = "archived", "Archived"
+    DELETED = "deleted", "Deleted"
+
+
+class WikiGenerationType(models.TextChoices):
+    AI = "ai", "AI"
+    HUMAN = "human", "Human"
+
+
+class VectorField(models.Field):
+    description = "PostgreSQL vector field"
+
+    def __init__(self, *args, dimensions, **kwargs):
+        self.dimensions = dimensions
+        super().__init__(*args, **kwargs)
+
+    def db_type(self, connection):
+        return f"vector({self.dimensions})"
+
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        kwargs["dimensions"] = self.dimensions
+        return name, path, args, kwargs
+
+    def get_internal_type(self):
+        return "TextField"
+
+    def get_prep_value(self, value):
+        if value is None or isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple)):
+            return "[" + ",".join(str(float(item)) for item in value) + "]"
+        return str(value)
+
+
+class PostgresEnumField(models.CharField):
+    def __init__(self, *args, enum_type, **kwargs):
+        self.enum_type = enum_type
+        super().__init__(*args, **kwargs)
+
+    def db_type(self, connection):
+        return self.enum_type
+
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        kwargs["enum_type"] = self.enum_type
+        return name, path, args, kwargs
+
+
 class Tag(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=50)
@@ -160,3 +211,101 @@ class SourceChunk(models.Model):
                 name="uq_source_chunks_document_chunk_index",
             )
         ]
+
+
+class ChunkEmbedding(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    source_chunk = models.ForeignKey(
+        SourceChunk,
+        on_delete=models.CASCADE,
+        related_name="embeddings",
+    )
+    embedding_model = models.CharField(max_length=100)
+    embedding_dim = models.IntegerField()
+    embedding = VectorField(dimensions=1536)
+    content_hash = models.CharField(max_length=64, blank=True, null=True)
+    created_at = models.DateTimeField(default=timezone.now, editable=False)
+
+    class Meta:
+        db_table = "chunk_embeddings"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["source_chunk", "embedding_model"],
+                name="uq_chunk_embeddings_source_chunk_model",
+            )
+        ]
+
+
+class WikiDocument(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    title = models.CharField(max_length=255)
+    slug = models.CharField(max_length=255, unique=True)
+    summary = models.TextField()
+    current_revision = models.ForeignKey(
+        "WikiRevision",
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        related_name="+",
+    )
+    status = PostgresEnumField(
+        max_length=20,
+        enum_type="wiki_document_status",
+        choices=WikiDocumentStatus.choices,
+        default=WikiDocumentStatus.PUBLISHED,
+    )
+    created_at = models.DateTimeField(default=timezone.now, editable=False)
+    updated_at = models.DateTimeField(default=timezone.now)
+
+    class Meta:
+        db_table = "wiki_documents"
+
+    def __str__(self):
+        return self.title
+
+
+class WikiRevision(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    wiki_document = models.ForeignKey(
+        WikiDocument,
+        on_delete=models.CASCADE,
+        related_name="revisions",
+    )
+    revision_number = models.IntegerField()
+    content_markdown = models.TextField()
+    generation_type = PostgresEnumField(
+        max_length=20,
+        enum_type="wiki_generation_type",
+        choices=WikiGenerationType.choices,
+        default=WikiGenerationType.AI,
+    )
+    generation_model = models.CharField(max_length=100, blank=True, null=True)
+    created_at = models.DateTimeField(default=timezone.now, editable=False)
+
+    class Meta:
+        db_table = "wiki_revisions"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["wiki_document", "revision_number"],
+                name="uq_wiki_revisions_document_revision",
+            )
+        ]
+
+
+class WikiRevisionSource(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    wiki_revision = models.ForeignKey(
+        WikiRevision,
+        on_delete=models.CASCADE,
+        related_name="sources",
+    )
+    source_chunk = models.ForeignKey(
+        SourceChunk,
+        on_delete=models.RESTRICT,
+        related_name="wiki_revision_sources",
+    )
+    evidence_text = models.TextField(blank=True, null=True)
+    created_at = models.DateTimeField(default=timezone.now, editable=False)
+
+    class Meta:
+        db_table = "wiki_revision_sources"

--- a/apps/core/models.py
+++ b/apps/core/models.py
@@ -1,5 +1,6 @@
 import uuid
 
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
 
@@ -62,6 +63,10 @@ class VectorField(models.Field):
         if value is None or isinstance(value, str):
             return value
         if isinstance(value, (list, tuple)):
+            if len(value) != self.dimensions:
+                raise ValidationError(
+                    f"Expected {self.dimensions} embedding dimensions, got {len(value)}."
+                )
             return "[" + ",".join(str(float(item)) for item in value) + "]"
         return str(value)
 

--- a/apps/core/search.py
+++ b/apps/core/search.py
@@ -1,3 +1,5 @@
+from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
+from django.db import connection
 from django.db.models import Q
 from django.urls import reverse
 
@@ -6,17 +8,41 @@ from .models import WikiDocument, WikiDocumentStatus
 
 def get_wiki_search_results(*, query="", limit=12):
     documents = (
-        WikiDocument.objects.filter(status=WikiDocumentStatus.PUBLISHED)
+        WikiDocument.objects.filter(
+            status=WikiDocumentStatus.PUBLISHED,
+            current_revision__isnull=False,
+        )
         .select_related("current_revision")
         .order_by("-updated_at")
     )
     normalized_query = query.strip()
     if normalized_query:
-        documents = documents.filter(
-            Q(title__icontains=normalized_query)
-            | Q(summary__icontains=normalized_query)
-            | Q(current_revision__content_markdown__icontains=normalized_query)
-        )
+        if connection.vendor == "postgresql":
+            search_vector = (
+                SearchVector("title", weight="A", config="simple")
+                + SearchVector("summary", weight="B", config="simple")
+                + SearchVector(
+                    "current_revision__content_markdown",
+                    weight="C",
+                    config="simple",
+                )
+            )
+            search_query = SearchQuery(
+                normalized_query,
+                config="simple",
+                search_type="websearch",
+            )
+            documents = documents.annotate(
+                search_vector=search_vector,
+                search_rank=SearchRank(search_vector, search_query),
+            ).filter(search_vector=search_query)
+            documents = documents.order_by("-search_rank", "-updated_at")
+        else:
+            documents = documents.filter(
+                Q(title__icontains=normalized_query)
+                | Q(summary__icontains=normalized_query)
+                | Q(current_revision__content_markdown__icontains=normalized_query)
+            )
 
     total_count = documents.count()
     documents = list(documents[:limit])

--- a/apps/core/search.py
+++ b/apps/core/search.py
@@ -1,0 +1,37 @@
+from django.db.models import Q
+from django.urls import reverse
+
+from .models import WikiDocument, WikiDocumentStatus
+
+
+def get_wiki_search_results(*, query="", limit=12):
+    documents = (
+        WikiDocument.objects.filter(status=WikiDocumentStatus.PUBLISHED)
+        .select_related("current_revision")
+        .order_by("-updated_at")
+    )
+    normalized_query = query.strip()
+    if normalized_query:
+        documents = documents.filter(
+            Q(title__icontains=normalized_query)
+            | Q(summary__icontains=normalized_query)
+            | Q(current_revision__content_markdown__icontains=normalized_query)
+        )
+
+    total_count = documents.count()
+    documents = list(documents[:limit])
+    return {
+        "query": normalized_query,
+        "total_count": total_count,
+        "items": [
+            {
+                "category": "문서",
+                "updated_at": document.updated_at,
+                "title": document.title,
+                "summary": document.summary,
+                "tags": [],
+                "url": reverse("wiki_detail", kwargs={"slug": document.slug}),
+            }
+            for document in documents
+        ],
+    }

--- a/apps/core/templatetags/markdown_extras.py
+++ b/apps/core/templatetags/markdown_extras.py
@@ -1,0 +1,98 @@
+import bleach
+import markdown
+from bleach.css_sanitizer import CSSSanitizer
+from django import template
+from django.utils.safestring import mark_safe
+
+from apps.core.wiki_markdown import build_markdown_context
+
+register = template.Library()
+
+ALLOWED_TAGS = [
+    "a",
+    "blockquote",
+    "br",
+    "code",
+    "div",
+    "em",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "hr",
+    "input",
+    "li",
+    "ol",
+    "p",
+    "pre",
+    "span",
+    "strong",
+    "table",
+    "tbody",
+    "td",
+    "th",
+    "thead",
+    "tr",
+    "ul",
+]
+ALLOWED_ATTRIBUTES = {
+    "*": ["class", "id"],
+    "a": ["href", "title"],
+    "div": ["class", "style"],
+    "span": ["class", "style"],
+    "code": ["class", "style"],
+    "pre": ["class", "style"],
+    "input": ["checked", "disabled", "type"],
+}
+CSS_SANITIZER = CSSSanitizer(
+    allowed_css_properties=[
+        "background-color",
+        "color",
+        "display",
+        "font-style",
+        "font-weight",
+        "margin",
+        "padding-left",
+        "text-decoration",
+    ]
+)
+
+
+@register.filter
+def render_markdown(value):
+    if not value:
+        return ""
+
+    processed_markdown, _ = build_markdown_context(value)
+    rendered = markdown.markdown(
+        processed_markdown,
+        extensions=[
+            "markdown.extensions.attr_list",
+            "markdown.extensions.codehilite",
+            "markdown.extensions.extra",
+            "markdown.extensions.nl2br",
+            "markdown.extensions.sane_lists",
+            "pymdownx.arithmatex",
+            "pymdownx.tasklist",
+        ],
+        extension_configs={
+            "markdown.extensions.codehilite": {
+                "guess_lang": False,
+                "noclasses": True,
+                "pygments_style": "monokai",
+            },
+            "pymdownx.arithmatex": {"generic": True},
+            "pymdownx.tasklist": {"clickable_checkbox": False},
+        },
+        output_format="html5",
+    )
+    sanitized = bleach.clean(
+        rendered,
+        tags=ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRIBUTES,
+        css_sanitizer=CSS_SANITIZER,
+        strip=True,
+    )
+    return mark_safe(sanitized)

--- a/apps/core/templatetags/markdown_extras.py
+++ b/apps/core/templatetags/markdown_extras.py
@@ -1,63 +1,9 @@
-import bleach
-import markdown
-from bleach.css_sanitizer import CSSSanitizer
 from django import template
 from django.utils.safestring import mark_safe
 
-from apps.core.wiki_markdown import build_markdown_context
+from apps.core.markdown_rendering import build_rendered_markdown
 
 register = template.Library()
-
-ALLOWED_TAGS = [
-    "a",
-    "blockquote",
-    "br",
-    "code",
-    "div",
-    "em",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "hr",
-    "input",
-    "li",
-    "ol",
-    "p",
-    "pre",
-    "span",
-    "strong",
-    "table",
-    "tbody",
-    "td",
-    "th",
-    "thead",
-    "tr",
-    "ul",
-]
-ALLOWED_ATTRIBUTES = {
-    "*": ["class", "id"],
-    "a": ["href", "title"],
-    "div": ["class", "style"],
-    "span": ["class", "style"],
-    "code": ["class", "style"],
-    "pre": ["class", "style"],
-    "input": ["checked", "disabled", "type"],
-}
-CSS_SANITIZER = CSSSanitizer(
-    allowed_css_properties=[
-        "background-color",
-        "color",
-        "display",
-        "font-style",
-        "font-weight",
-        "margin",
-        "padding-left",
-        "text-decoration",
-    ]
-)
 
 
 @register.filter
@@ -65,34 +11,5 @@ def render_markdown(value):
     if not value:
         return ""
 
-    processed_markdown, _ = build_markdown_context(value)
-    rendered = markdown.markdown(
-        processed_markdown,
-        extensions=[
-            "markdown.extensions.attr_list",
-            "markdown.extensions.codehilite",
-            "markdown.extensions.extra",
-            "markdown.extensions.nl2br",
-            "markdown.extensions.sane_lists",
-            "pymdownx.arithmatex",
-            "pymdownx.tasklist",
-        ],
-        extension_configs={
-            "markdown.extensions.codehilite": {
-                "guess_lang": False,
-                "noclasses": True,
-                "pygments_style": "monokai",
-            },
-            "pymdownx.arithmatex": {"generic": True},
-            "pymdownx.tasklist": {"clickable_checkbox": False},
-        },
-        output_format="html5",
-    )
-    sanitized = bleach.clean(
-        rendered,
-        tags=ALLOWED_TAGS,
-        attributes=ALLOWED_ATTRIBUTES,
-        css_sanitizer=CSS_SANITIZER,
-        strip=True,
-    )
-    return mark_safe(sanitized)
+    rendered_markdown, _ = build_rendered_markdown(value)
+    return mark_safe(rendered_markdown)

--- a/apps/core/tests/test_search_views.py
+++ b/apps/core/tests/test_search_views.py
@@ -141,7 +141,7 @@ class SearchViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'value="회고"', html=False)
 
-    def test_integrated_search_returns_empty_response_for_blank_htmx_query(self):
+    def test_integrated_search_returns_empty_state_for_blank_htmx_query(self):
         response = self.client.get(
             "/search/",
             {"q": ""},
@@ -149,7 +149,11 @@ class SearchViewTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, b"")
+        self.assertContains(response, "검색어를 입력해 주세요")
+        self.assertContains(
+            response,
+            "찾고 싶은 문서 제목, 요약, 본문 키워드를 입력하면 결과를 바로 보여줍니다.",
+        )
 
     def test_integrated_search_shows_recent_documents_when_query_is_blank(self):
         document = WikiDocument.objects.create(

--- a/apps/core/tests/test_search_views.py
+++ b/apps/core/tests/test_search_views.py
@@ -1,0 +1,186 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.core.models import (
+    WikiDocument,
+    WikiDocumentStatus,
+    WikiGenerationType,
+    WikiRevision,
+)
+
+
+@override_settings(
+    SESSION_ENGINE="django.contrib.sessions.backends.db",
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "hivewiki-search-test-cache",
+        }
+    },
+)
+class SearchViewTests(TestCase):
+    def test_integrated_search_only_shows_matching_wiki_documents(self):
+        matching_document = WikiDocument.objects.create(
+            title="커뮤니티 질문을 위키로 전환하는 기준",
+            slug="community-to-wiki-criteria",
+            summary="질문을 문서화하는 기준입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        matching_revision = WikiRevision.objects.create(
+            wiki_document=matching_document,
+            revision_number=1,
+            content_markdown="## 선정 기준\n\n- 반복 질문",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        matching_document.current_revision = matching_revision
+        matching_document.save(update_fields=["current_revision"])
+
+        non_matching_document = WikiDocument.objects.create(
+            title="캡스톤 위키 운영 가이드",
+            slug="capstone-wiki-guide",
+            summary="문서 운영 가이드입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        non_matching_revision = WikiRevision.objects.create(
+            wiki_document=non_matching_document,
+            revision_number=1,
+            content_markdown="## 운영 원칙",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        non_matching_document.current_revision = non_matching_revision
+        non_matching_document.save(update_fields=["current_revision"])
+
+        response = self.client.get("/search/", {"q": "선정 기준"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "문서 검색")
+        self.assertContains(response, "커뮤니티 질문을 위키로 전환하는 기준")
+        self.assertNotContains(response, "캡스톤 위키 운영 가이드")
+        self.assertNotContains(response, "게시글 결과")
+
+    def test_integrated_search_shows_total_count_before_limit(self):
+        for index in range(18):
+            document = WikiDocument.objects.create(
+                title=f"운영 기준 문서 {index}",
+                slug=f"operations-guide-{index}",
+                summary="운영 기준을 정리한 문서입니다.",
+                status=WikiDocumentStatus.PUBLISHED,
+                updated_at=timezone.now() + timezone.timedelta(minutes=index),
+            )
+            revision = WikiRevision.objects.create(
+                wiki_document=document,
+                revision_number=1,
+                content_markdown="## 운영 기준",
+                generation_type=WikiGenerationType.AI,
+                generation_model="gpt-5.5",
+            )
+            document.current_revision = revision
+            document.save(update_fields=["current_revision"])
+
+        response = self.client.get("/search/", {"q": "운영 기준"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "문서 18건")
+        self.assertContains(response, "18건")
+        self.assertContains(response, "운영 기준 문서 17")
+        self.assertNotContains(response, "운영 기준 문서 0")
+
+    def test_wiki_home_filters_documents_for_htmx_requests(self):
+        matching_document = WikiDocument.objects.create(
+            title="운영 회고 문서",
+            slug="retrospective-guide",
+            summary="운영 회고를 정리한 문서입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        matching_revision = WikiRevision.objects.create(
+            wiki_document=matching_document,
+            revision_number=1,
+            content_markdown="## 회고 항목",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        matching_document.current_revision = matching_revision
+        matching_document.save(update_fields=["current_revision"])
+
+        response = self.client.get(
+            "/wiki/",
+            {"q": "회고"},
+            headers={"HX-Request": "true"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '"회고" 검색 결과')
+        self.assertContains(response, "운영 회고 문서")
+
+    def test_wiki_home_full_page_keeps_query_in_search_input(self):
+        document = WikiDocument.objects.create(
+            title="운영 회고 문서",
+            slug="retrospective-guide",
+            summary="운영 회고를 정리한 문서입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        revision = WikiRevision.objects.create(
+            wiki_document=document,
+            revision_number=1,
+            content_markdown="## 회고 항목",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        document.current_revision = revision
+        document.save(update_fields=["current_revision"])
+
+        response = self.client.get("/wiki/", {"q": "회고"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'value="회고"', html=False)
+
+    def test_integrated_search_returns_empty_response_for_blank_htmx_query(self):
+        response = self.client.get(
+            "/search/",
+            {"q": ""},
+            headers={"HX-Request": "true"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"")
+
+    def test_integrated_search_shows_recent_documents_when_query_is_blank(self):
+        document = WikiDocument.objects.create(
+            title="최근 운영 문서",
+            slug="recent-operations-doc",
+            summary="최근 업데이트된 문서입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        revision = WikiRevision.objects.create(
+            wiki_document=document,
+            revision_number=1,
+            content_markdown="## 최근 변경 사항",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        document.current_revision = revision
+        document.save(update_fields=["current_revision"])
+
+        response = self.client.get("/search/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            "최근 업데이트된 문서를 둘러보고, 필요한 경우 바로 검색으로 좁혀갈 수 있습니다.",
+        )
+        self.assertContains(response, "최근 운영 문서")
+        self.assertNotContains(response, "검색어를 입력해 주세요")
+
+    def test_integrated_search_full_page_keeps_query_in_search_input(self):
+        response = self.client.get(reverse("integrated_search"), {"q": "회고"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'value="회고"', html=False)

--- a/apps/core/tests/test_wiki_views.py
+++ b/apps/core/tests/test_wiki_views.py
@@ -66,9 +66,7 @@ class WikiViewTests(TestCase):
         self.assertContains(response, "커뮤니티 질문을 위키로 전환하는 기준")
         self.assertContains(response, '<h2 id="선정-기준">선정 기준</h2>', html=True)
         self.assertContains(response, "<li>반복 질문</li>", html=True)
-        self.assertContains(
-            response, "&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;"
-        )
+        self.assertContains(response, "&lt;script&gt;alert('xss')&lt;/script&gt;")
         self.assertContains(response, "data-toc-link")
         self.assertContains(response, 'href="#선정-기준"')
         self.assertContains(response, "문서 공유")
@@ -85,6 +83,34 @@ class WikiViewTests(TestCase):
         )
         self.assertContains(response, 'data-copy-success-text="링크 복사됨!"')
         self.assertContains(response, 'id="human-copy"')
+        self.assertNotContains(response, 'style="')
+
+    def test_wiki_detail_adds_safe_rel_to_links(self):
+        document = WikiDocument.objects.create(
+            title="외부 링크 문서",
+            slug="external-link-doc",
+            summary="외부 링크 보안 속성을 확인합니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        revision = WikiRevision.objects.create(
+            wiki_document=document,
+            revision_number=1,
+            content_markdown="[문서 링크](https://example.com)",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        document.current_revision = revision
+        document.save(update_fields=["current_revision"])
+
+        response = self.client.get("/wiki/external-link-doc/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            '<a href="https://example.com" rel="noopener noreferrer">문서 링크</a>',
+            html=True,
+        )
 
     def test_wiki_detail_does_not_repeat_document_title_from_leading_h1(self):
         document = WikiDocument.objects.create(
@@ -137,3 +163,16 @@ class WikiViewTests(TestCase):
 
         self.assertEqual(home_response.status_code, 200)
         self.assertEqual(detail_response.status_code, 200)
+
+    def test_wiki_detail_requires_current_revision_for_published_document(self):
+        WikiDocument.objects.create(
+            title="리비전 없는 공개 문서",
+            slug="published-without-revision",
+            summary="공개 문서는 현재 리비전이 있어야 합니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+
+        response = self.client.get("/wiki/published-without-revision/")
+
+        self.assertEqual(response.status_code, 404)

--- a/apps/core/tests/test_wiki_views.py
+++ b/apps/core/tests/test_wiki_views.py
@@ -112,6 +112,37 @@ class WikiViewTests(TestCase):
             html=True,
         )
 
+    def test_wiki_detail_renders_code_blocks_without_double_escaped_entities(self):
+        document = WikiDocument.objects.create(
+            title="코드 블록 문서",
+            slug="code-block-doc",
+            summary="코드 블록 렌더링을 확인합니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        revision = WikiRevision.objects.create(
+            wiki_document=document,
+            revision_number=1,
+            content_markdown="""```python
+def promote_question_to_wiki(question, chunks):
+    if question.repeat_count < 2:
+        return "keep_in_community"
+```
+""",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        document.current_revision = revision
+        document.save(update_fields=["current_revision"])
+
+        response = self.client.get("/wiki/code-block-doc/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "&quot;keep_in_community&quot;")
+        self.assertContains(response, '<span class="o">&lt;</span>', html=False)
+        self.assertNotContains(response, "&amp;quot;keep_in_community&amp;quot;")
+        self.assertNotContains(response, "&amp;lt;")
+
     def test_wiki_detail_does_not_repeat_document_title_from_leading_h1(self):
         document = WikiDocument.objects.create(
             title="커뮤니티 질문을 위키로 전환하는 기준",

--- a/apps/core/tests/test_wiki_views.py
+++ b/apps/core/tests/test_wiki_views.py
@@ -1,0 +1,139 @@
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from apps.core.models import (
+    WikiDocument,
+    WikiDocumentStatus,
+    WikiGenerationType,
+    WikiRevision,
+)
+
+
+@override_settings(
+    SESSION_ENGINE="django.contrib.sessions.backends.db",
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "hivewiki-wiki-test-cache",
+        }
+    },
+)
+class WikiViewTests(TestCase):
+    def test_wiki_home_links_to_detail_page(self):
+        document = WikiDocument.objects.create(
+            title="캡스톤 위키 운영 가이드",
+            slug="capstone-wiki-guide",
+            summary="문서 수집과 승격 기준을 정리한 문서입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        revision = WikiRevision.objects.create(
+            wiki_document=document,
+            revision_number=1,
+            content_markdown="# 캡스톤 위키 운영 가이드",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        document.current_revision = revision
+        document.save(update_fields=["current_revision"])
+
+        response = self.client.get("/wiki/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "/wiki/capstone-wiki-guide/")
+
+    def test_wiki_detail_renders_current_revision(self):
+        document = WikiDocument.objects.create(
+            title="커뮤니티 질문을 위키로 전환하는 기준",
+            slug="community-to-wiki-criteria",
+            summary="질문을 위키 문서로 만드는 기준입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        revision = WikiRevision.objects.create(
+            wiki_document=document,
+            revision_number=1,
+            content_markdown="## 선정 기준\n\n- 반복 질문\n\n<script>alert('xss')</script>",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        document.current_revision = revision
+        document.save(update_fields=["current_revision"])
+
+        response = self.client.get("/wiki/community-to-wiki-criteria/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "커뮤니티 질문을 위키로 전환하는 기준")
+        self.assertContains(response, '<h2 id="선정-기준">선정 기준</h2>', html=True)
+        self.assertContains(response, "<li>반복 질문</li>", html=True)
+        self.assertContains(
+            response, "&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;"
+        )
+        self.assertContains(response, "data-toc-link")
+        self.assertContains(response, 'href="#선정-기준"')
+        self.assertContains(response, "문서 공유")
+        self.assertContains(response, "읽기용 복사")
+        self.assertContains(response, "에이전트용 복사")
+        self.assertNotContains(response, "슬러그")
+        self.assertContains(
+            response,
+            'data-copy-label="공유 링크"',
+        )
+        self.assertContains(
+            response,
+            'data-copy-label="에이전트용 사본"',
+        )
+        self.assertContains(response, 'data-copy-success-text="링크 복사됨!"')
+        self.assertContains(response, 'id="human-copy"')
+
+    def test_wiki_detail_does_not_repeat_document_title_from_leading_h1(self):
+        document = WikiDocument.objects.create(
+            title="커뮤니티 질문을 위키로 전환하는 기준",
+            slug="community-to-wiki-criteria",
+            summary="질문을 위키 문서로 만드는 기준입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        revision = WikiRevision.objects.create(
+            wiki_document=document,
+            revision_number=1,
+            content_markdown="# 커뮤니티 질문을 위키로 전환하는 기준\n\n## 선정 기준",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        document.current_revision = revision
+        document.save(update_fields=["current_revision"])
+
+        response = self.client.get("/wiki/community-to-wiki-criteria/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            '<h1 id="커뮤니티-질문을-위키로-전환하는-기준">커뮤니티 질문을 위키로 전환하는 기준</h1>',
+            html=True,
+        )
+        self.assertContains(response, '<h2 id="선정-기준">선정 기준</h2>', html=True)
+
+    def test_wiki_pages_are_public(self):
+        document = WikiDocument.objects.create(
+            title="공개 위키 문서",
+            slug="public-wiki-doc",
+            summary="로그인 없이 읽을 수 있어야 합니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        revision = WikiRevision.objects.create(
+            wiki_document=document,
+            revision_number=1,
+            content_markdown="## 공개 섹션",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        document.current_revision = revision
+        document.save(update_fields=["current_revision"])
+
+        home_response = self.client.get("/wiki/")
+        detail_response = self.client.get("/wiki/public-wiki-doc/")
+
+        self.assertEqual(home_response.status_code, 200)
+        self.assertEqual(detail_response.status_code, 200)

--- a/apps/core/urls.py
+++ b/apps/core/urls.py
@@ -41,5 +41,6 @@ urlpatterns = [
     ),
     path("community/", views.community_list, name="community_list"),
     path("wiki/", views.wiki_home, name="wiki_home"),
+    path("wiki/<slug:slug>/", views.wiki_detail, name="wiki_detail"),
     path("search/", views.integrated_search, name="integrated_search"),
 ]

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -14,6 +14,7 @@ from apps.accounts.models import HiveUser, OAuthAccount, UserRole, UserStatus
 from apps.accounts.services import purge_user_sessions
 
 from .forms import SourceForm, TagForm
+from .markdown_rendering import get_cached_revision_render
 from .models import (
     IngestionJob,
     Source,
@@ -23,11 +24,7 @@ from .models import (
     WikiDocumentStatus,
 )
 from .search import get_wiki_search_results
-from .wiki_markdown import (
-    annotate_toc_items,
-    build_markdown_context,
-    strip_leading_title_heading,
-)
+from .wiki_markdown import strip_leading_title_heading
 
 logger = logging.getLogger(__name__)
 
@@ -145,18 +142,16 @@ def wiki_home(request):
 
 def wiki_detail(request, slug):
     document = get_object_or_404(
-        WikiDocument.objects.select_related("current_revision"),
+        WikiDocument.objects.select_related("current_revision").filter(
+            current_revision__isnull=False
+        ),
         slug=slug,
         status=WikiDocumentStatus.PUBLISHED,
     )
     revision = document.current_revision
-    display_markdown = (
-        strip_leading_title_heading(revision.content_markdown, document.title)
-        if revision
-        else ""
+    rendered_revision = get_cached_revision_render(
+        revision=revision, title=document.title
     )
-    _, toc_items = build_markdown_context(display_markdown)
-    toc_items = annotate_toc_items(toc_items)
     share_url = request.build_absolute_uri(
         reverse("wiki_detail", kwargs={"slug": document.slug})
     )
@@ -167,8 +162,10 @@ def wiki_detail(request, slug):
             "page_heading": document.title,
             "document": document,
             "revision": revision,
-            "display_markdown": display_markdown,
-            "toc_items": toc_items,
+            "query": "",
+            "display_markdown": rendered_revision["display_markdown"],
+            "rendered_markdown": rendered_revision["rendered_markdown"],
+            "toc_items": rendered_revision["toc_items"],
             "share_url": share_url,
             "copy_human_text": _build_human_copy(document, revision, share_url),
             "copy_agent_text": _build_agent_copy(document, revision, share_url),
@@ -178,13 +175,11 @@ def wiki_detail(request, slug):
 
 def integrated_search(request):
     query = request.GET.get("q", "").strip()
-    if request.headers.get("HX-Request") == "true" and not query:
-        return HttpResponse("")
-
+    is_htmx_request = request.headers.get("HX-Request") == "true"
     search_results = get_wiki_search_results(query=query, limit=16)
     template_name = (
         "partials/global_search_results.html"
-        if request.headers.get("HX-Request") == "true"
+        if is_htmx_request
         else "pages/search/results.html"
     )
     return render(
@@ -196,6 +191,7 @@ def integrated_search(request):
             "list_tags": LIST_TAGS,
             "wiki_items": search_results["items"],
             "wiki_result_count": search_results["total_count"],
+            "show_blank_query_state": is_htmx_request and not query,
         },
     )
 

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -5,6 +5,7 @@ from django.db import transaction
 from django.db.models import Count, Prefetch, Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_POST
 
@@ -13,7 +14,20 @@ from apps.accounts.models import HiveUser, OAuthAccount, UserRole, UserStatus
 from apps.accounts.services import purge_user_sessions
 
 from .forms import SourceForm, TagForm
-from .models import IngestionJob, Source, SourceDocument, Tag
+from .models import (
+    IngestionJob,
+    Source,
+    SourceDocument,
+    Tag,
+    WikiDocument,
+    WikiDocumentStatus,
+)
+from .search import get_wiki_search_results
+from .wiki_markdown import (
+    annotate_toc_items,
+    build_markdown_context,
+    strip_leading_title_heading,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -109,23 +123,67 @@ def community_list(request):
     )
 
 
-@login_required
 def wiki_home(request):
+    query = request.GET.get("q", "").strip()
+    search_results = get_wiki_search_results(query=query, limit=8)
+    context = {
+        "page_heading": "Wiki",
+        "list_tags": LIST_TAGS,
+        "query": query,
+        "wiki_items": search_results["items"],
+        "wiki_result_count": search_results["total_count"],
+    }
+    if request.headers.get("HX-Request") == "true":
+        return render(request, "partials/wiki_search_results.html", context)
+
     return render(
         request,
         "pages/wiki/search_home.html",
+        context,
+    )
+
+
+def wiki_detail(request, slug):
+    document = get_object_or_404(
+        WikiDocument.objects.select_related("current_revision"),
+        slug=slug,
+        status=WikiDocumentStatus.PUBLISHED,
+    )
+    revision = document.current_revision
+    display_markdown = (
+        strip_leading_title_heading(revision.content_markdown, document.title)
+        if revision
+        else ""
+    )
+    _, toc_items = build_markdown_context(display_markdown)
+    toc_items = annotate_toc_items(toc_items)
+    share_url = request.build_absolute_uri(
+        reverse("wiki_detail", kwargs={"slug": document.slug})
+    )
+    return render(
+        request,
+        "pages/wiki/detail.html",
         {
-            "page_heading": "Wiki",
-            "list_tags": LIST_TAGS,
-            "wiki_items": FEATURED_WIKI,
+            "page_heading": document.title,
+            "document": document,
+            "revision": revision,
+            "display_markdown": display_markdown,
+            "toc_items": toc_items,
+            "share_url": share_url,
+            "copy_human_text": _build_human_copy(document, revision, share_url),
+            "copy_agent_text": _build_agent_copy(document, revision, share_url),
         },
     )
 
 
 def integrated_search(request):
     query = request.GET.get("q", "").strip()
+    if request.headers.get("HX-Request") == "true" and not query:
+        return HttpResponse("")
+
+    search_results = get_wiki_search_results(query=query, limit=16)
     template_name = (
-        "partials/search_results.html"
+        "partials/global_search_results.html"
         if request.headers.get("HX-Request") == "true"
         else "pages/search/results.html"
     )
@@ -136,10 +194,51 @@ def integrated_search(request):
             "page_heading": "Search",
             "query": query,
             "list_tags": LIST_TAGS,
-            "wiki_items": FEATURED_WIKI,
-            "post_items": FEATURED_POSTS,
+            "wiki_items": search_results["items"],
+            "wiki_result_count": search_results["total_count"],
         },
     )
+
+
+def _build_human_copy(document, revision, share_url):
+    body = (
+        strip_leading_title_heading(revision.content_markdown, document.title).strip()
+        if revision
+        else ""
+    )
+    parts = [
+        document.title,
+        "",
+        document.summary.strip(),
+        "",
+        f"링크: {share_url}",
+    ]
+    if body:
+        parts.extend(["", body])
+    return "\n".join(parts).strip()
+
+
+def _build_agent_copy(document, revision, share_url):
+    body = (
+        strip_leading_title_heading(revision.content_markdown, document.title).strip()
+        if revision
+        else ""
+    )
+    lines = [
+        "wiki_context:",
+        f"  title: {document.title}",
+        f"  url: {share_url}",
+        "  summary: |",
+        *[f"    {line}" for line in document.summary.strip().splitlines()],
+    ]
+    if body:
+        lines.extend(
+            [
+                "content_markdown: |",
+                *[f"  {line}" for line in body.splitlines()],
+            ]
+        )
+    return "\n".join(lines).strip()
 
 
 @login_required

--- a/apps/core/wiki_markdown.py
+++ b/apps/core/wiki_markdown.py
@@ -1,0 +1,123 @@
+import re
+
+from django.utils.text import slugify
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)(?:\s+#+\s*)?$")
+INLINE_CODE_RE = re.compile(r"`([^`]*)`")
+MARKDOWN_LINK_RE = re.compile(r"!?(\[([^\]]+)\]\([^)]+\))")
+MARKDOWN_EMPHASIS_RE = re.compile(r"[*_~]+")
+
+
+def build_markdown_context(
+    markdown_text: str,
+) -> tuple[str, list[dict[str, str | int]]]:
+    if not markdown_text:
+        return "", []
+
+    seen_ids: dict[str, int] = {}
+    processed_lines: list[str] = []
+    toc_items: list[dict[str, str | int]] = []
+
+    for line in markdown_text.splitlines():
+        match = HEADING_RE.match(line)
+        if not match:
+            processed_lines.append(line)
+            continue
+
+        hashes, raw_heading = match.groups()
+        heading_text = _plain_heading_text(raw_heading).strip()
+        heading_id = _unique_heading_id(heading_text, seen_ids)
+        level = len(hashes)
+
+        processed_lines.append(f"{hashes} {raw_heading} {{#{heading_id}}}")
+        toc_items.append(
+            {
+                "level": level,
+                "text": heading_text or raw_heading.strip(),
+                "id": heading_id,
+            }
+        )
+
+    return "\n".join(processed_lines), toc_items
+
+
+def annotate_toc_items(
+    toc_items: list[dict[str, str | int]],
+) -> list[dict[str, str | int]]:
+    if not toc_items:
+        return []
+
+    min_level = min(int(item["level"]) for item in toc_items)
+    counters = [0] * 6
+    annotated_items: list[dict[str, str | int]] = []
+
+    for item in toc_items:
+        normalized_level = int(item["level"]) - min_level + 1
+        counters[normalized_level - 1] += 1
+        for index in range(normalized_level, len(counters)):
+            counters[index] = 0
+
+        annotated_items.append(
+            {
+                **item,
+                "toc_level": normalized_level,
+                "label": _toc_label(normalized_level, counters[normalized_level - 1]),
+            }
+        )
+
+    return annotated_items
+
+
+def strip_leading_title_heading(markdown_text: str, title: str) -> str:
+    if not markdown_text:
+        return ""
+
+    lines = markdown_text.splitlines()
+    if not lines:
+        return markdown_text
+
+    first_line = lines[0].strip()
+    match = HEADING_RE.match(first_line)
+    if not match:
+        return markdown_text
+
+    hashes, raw_heading = match.groups()
+    if len(hashes) != 1:
+        return markdown_text
+
+    heading_text = _plain_heading_text(raw_heading)
+    if heading_text != title.strip():
+        return markdown_text
+
+    remaining_lines = lines[1:]
+    while remaining_lines and not remaining_lines[0].strip():
+        remaining_lines.pop(0)
+    return "\n".join(remaining_lines)
+
+
+def _plain_heading_text(value: str) -> str:
+    plain_text = MARKDOWN_LINK_RE.sub(r"\2", value)
+    plain_text = INLINE_CODE_RE.sub(r"\1", plain_text)
+    plain_text = MARKDOWN_EMPHASIS_RE.sub("", plain_text)
+    return plain_text.strip()
+
+
+def _unique_heading_id(heading_text: str, seen_ids: dict[str, int]) -> str:
+    base_id = slugify(heading_text, allow_unicode=True) or "section"
+    count = seen_ids.get(base_id, 0)
+    seen_ids[base_id] = count + 1
+    if count == 0:
+        return base_id
+    return f"{base_id}-{count + 1}"
+
+
+def _toc_label(level: int, index: int) -> str:
+    if level == 1:
+        return f"{index}."
+    if level == 2:
+        return f"{chr(96 + index)}."
+    if level == 3:
+        return f"{index})"
+    if level == 4:
+        return f"{chr(64 + index)})"
+    return f"{index}."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,14 @@ description = "Web application for the HiveWiki project built with Django"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
 dependencies = [
+    "bleach>=6.2.0,<7.0",
     "django>=5.2.13,<6.0",
     "django-environ>=0.13.0",
     "django-htmx>=1.27.0",
+    "markdown>=3.9,<4.0",
+    "pymdown-extensions>=10.16.0,<11.0",
+    "pygments>=2.19.0,<3.0",
+    "tinycss2>=1.4.0,<2.0",
     "django-redis>=6.0.0",
     "django-tailwind>=4.4.2",
     "psycopg[binary]>=3.3.3",

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -89,6 +89,164 @@ h6 {
   color: var(--on-surface);
 }
 
+.reading-prose blockquote {
+  margin: 1.75rem 0;
+  border-left: 4px solid rgba(120, 89, 0, 0.32);
+  background: rgba(255, 193, 7, 0.08);
+  padding: 1rem 1.25rem;
+  color: var(--on-surface);
+}
+
+.reading-prose :not(pre) > code {
+  border-radius: 0.5rem;
+  background: rgba(28, 27, 27, 0.06);
+  padding: 0.15rem 0.45rem;
+  color: var(--on-surface);
+  font-size: 0.92em;
+}
+
+.reading-prose pre {
+  overflow-x: auto;
+  border-radius: 1.5rem;
+  background: linear-gradient(180deg, #151312 0%, #11100f 100%);
+  padding: 1.35rem 1.4rem;
+  color: #f8f5ef;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 18px 34px rgba(17, 16, 15, 0.18);
+  line-height: 1.7;
+}
+
+.reading-prose pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font-family:
+    "JetBrains Mono",
+    "SFMono-Regular",
+    "Cascadia Code",
+    "Fira Code",
+    monospace;
+  font-size: 0.95rem;
+}
+
+.reading-prose .codehilite {
+  position: relative;
+  margin: 1.8rem 0;
+}
+
+.reading-prose .codehilite pre {
+  margin: 0;
+}
+
+.reading-prose .task-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.reading-prose .task-list-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin: 0.9rem 0;
+}
+
+.reading-prose .task-list-item input[type="checkbox"] {
+  margin-top: 0.28rem;
+  accent-color: var(--primary);
+}
+
+.code-copy-button {
+  position: absolute;
+  top: 0.85rem;
+  right: 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.45rem 0.8rem;
+  color: rgba(248, 245, 239, 0.88);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  backdrop-filter: blur(8px);
+  transition:
+    background-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.code-copy-button:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.reading-prose table {
+  width: 100%;
+  overflow: hidden;
+  border-collapse: collapse;
+  border-radius: 1rem;
+  margin: 1.75rem 0;
+}
+
+.reading-prose thead {
+  background: rgba(120, 89, 0, 0.08);
+}
+
+.reading-prose th,
+.reading-prose td {
+  border-bottom: 1px solid rgba(212, 197, 171, 0.45);
+  padding: 0.85rem 1rem;
+  text-align: left;
+}
+
+.wiki-actions-panel {
+  position: relative;
+}
+
+.wiki-action-button {
+  border-radius: 1rem;
+  padding: 0.85rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  transition:
+    transform 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.wiki-action-button:hover {
+  transform: translateY(-1px);
+}
+
+.wiki-action-button--soft {
+  background: var(--surface-high);
+  color: var(--on-surface);
+}
+
+.wiki-action-button--soft:hover {
+  background: var(--surface-highest);
+}
+
+.wiki-action-button--strong {
+  background: #12100f;
+  color: #fff8e8;
+}
+
+.wiki-action-button--strong:hover {
+  background: #24201d;
+}
+
+.wiki-action-button.is-copied {
+  box-shadow: inset 0 0 0 1px rgba(120, 89, 0, 0.18);
+}
+
+.wiki-copy-feedback {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--primary-container) 48%, white);
+  padding: 0.7rem 0.95rem;
+  animation: flash-enter 180ms ease-out;
+}
+
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -139,6 +139,42 @@ h6 {
   margin: 0;
 }
 
+.reading-prose .codehilite .c,
+.reading-prose .codehilite .cm,
+.reading-prose .codehilite .c1 {
+  color: #8b887d;
+}
+
+.reading-prose .codehilite .k,
+.reading-prose .codehilite .kd,
+.reading-prose .codehilite .kn,
+.reading-prose .codehilite .ow {
+  color: #f92672;
+}
+
+.reading-prose .codehilite .nf,
+.reading-prose .codehilite .fm {
+  color: #a6e22e;
+}
+
+.reading-prose .codehilite .nb,
+.reading-prose .codehilite .bp,
+.reading-prose .codehilite .kc {
+  color: #66d9ef;
+}
+
+.reading-prose .codehilite .s,
+.reading-prose .codehilite .s1,
+.reading-prose .codehilite .s2,
+.reading-prose .codehilite .sa {
+  color: #e6db74;
+}
+
+.reading-prose .codehilite .mi,
+.reading-prose .codehilite .mf {
+  color: #ae81ff;
+}
+
 .reading-prose .task-list {
   list-style: none;
   padding-left: 0;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -3,10 +3,11 @@ document.body.addEventListener("htmx:afterSwap", (event) => {
   if (target && target.id) {
     target.dataset.lastUpdated = "true";
   }
-  formatTimezoneSensitiveElements(document.body.dataset.currentTimezone);
-  formatLocalDatetimeInputs(document.body.dataset.currentTimezone);
-  initializeWikiToc();
-  initializeCodeCopyButtons();
+  const root = target instanceof Element ? target : document.body;
+  formatTimezoneSensitiveElements(document.body.dataset.currentTimezone, root);
+  formatLocalDatetimeInputs(document.body.dataset.currentTimezone, root);
+  initializeWikiToc(root);
+  initializeCodeCopyButtons(root);
   renderMath(target || document.body);
 });
 
@@ -116,8 +117,8 @@ async function writeToClipboard(value) {
   }
 }
 
-function initializeCodeCopyButtons() {
-  document.querySelectorAll(".codehilite").forEach((block) => {
+function initializeCodeCopyButtons(root = document) {
+  root.querySelectorAll(".codehilite").forEach((block) => {
     if (!(block instanceof HTMLElement) || block.dataset.copyReady === "true") {
       return;
     }
@@ -133,7 +134,7 @@ function initializeCodeCopyButtons() {
     button.textContent = "Copy";
     button.addEventListener("click", async () => {
       try {
-        await writeToClipboard(codeNode.innerText);
+        await writeToClipboard(codeNode.textContent || "");
       } catch {
         return;
       }
@@ -169,9 +170,19 @@ function renderMath(root) {
   });
 }
 
-function initializeWikiToc() {
-  const tocLinks = Array.from(document.querySelectorAll("[data-toc-link]"));
+function initializeWikiToc(root = document) {
+  const tocNav =
+    root instanceof Element
+      ? root.querySelector("[data-toc-nav]") || document.querySelector("[data-toc-nav]")
+      : document.querySelector("[data-toc-nav]");
+  if (!(tocNav instanceof HTMLElement)) {
+    disconnectWikiTocObserver();
+    return;
+  }
+
+  const tocLinks = Array.from(tocNav.querySelectorAll("[data-toc-link]"));
   if (!tocLinks.length) {
+    disconnectWikiTocObserver();
     return;
   }
 
@@ -207,6 +218,7 @@ function initializeWikiToc() {
     return;
   }
 
+  disconnectWikiTocObserver();
   let activeId = headingIds[0];
   const observer = new IntersectionObserver(
     (entries) => {
@@ -236,6 +248,14 @@ function initializeWikiToc() {
   );
 
   headingMap.forEach((heading) => observer.observe(heading));
+  window.hiveWikiTocObserver = observer;
+}
+
+function disconnectWikiTocObserver() {
+  if (window.hiveWikiTocObserver instanceof IntersectionObserver) {
+    window.hiveWikiTocObserver.disconnect();
+    window.hiveWikiTocObserver = null;
+  }
 }
 
 document.addEventListener("keydown", (event) => {
@@ -262,12 +282,12 @@ function formatPartsToDate(parts, includeTime) {
   return `${dateText} ${values.hour}:${values.minute}`;
 }
 
-function formatTimezoneSensitiveElements(timezoneName) {
+function formatTimezoneSensitiveElements(timezoneName, root = document) {
   if (!timezoneName) {
     return;
   }
 
-  document.querySelectorAll("[data-local-datetime]").forEach((element) => {
+  root.querySelectorAll("[data-local-datetime]").forEach((element) => {
     const datetimeValue = element.dataset.localDatetime;
     if (!datetimeValue) {
       return;
@@ -313,12 +333,12 @@ function formatDateTimeLocalValue(date, timezoneName) {
   return `${values.year}-${values.month}-${values.day}T${values.hour}:${values.minute}`;
 }
 
-function formatLocalDatetimeInputs(timezoneName) {
+function formatLocalDatetimeInputs(timezoneName, root = document) {
   if (!timezoneName) {
     return;
   }
 
-  document.querySelectorAll("[data-local-datetime-input]").forEach((element) => {
+  root.querySelectorAll("[data-local-datetime-input]").forEach((element) => {
     const datetimeValue = element.dataset.localDatetimeSource;
     if (!datetimeValue) {
       return;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -5,6 +5,9 @@ document.body.addEventListener("htmx:afterSwap", (event) => {
   }
   formatTimezoneSensitiveElements(document.body.dataset.currentTimezone);
   formatLocalDatetimeInputs(document.body.dataset.currentTimezone);
+  initializeWikiToc();
+  initializeCodeCopyButtons();
+  renderMath(target || document.body);
 });
 
 function closeAdminModal() {
@@ -30,6 +33,210 @@ document.body.addEventListener("click", (event) => {
   }
   closeAdminModal();
 });
+
+document.body.addEventListener("click", async (event) => {
+  const copyTrigger =
+    event.target instanceof Element
+      ? event.target.closest("[data-copy-trigger]")
+      : null;
+  if (!copyTrigger) {
+    return;
+  }
+
+  const copySource = copyTrigger.dataset.copySource;
+  const copyNode = copySource ? document.getElementById(copySource) : null;
+  const copyText =
+    copyNode instanceof HTMLTextAreaElement
+      ? copyNode.value
+      : copyNode?.textContent;
+  if (!copyText) {
+    return;
+  }
+
+  try {
+    await writeToClipboard(copyText);
+  } catch {
+    return;
+  }
+
+  const panel = copyTrigger.closest(".wiki-actions-panel");
+  const labelNode = copyTrigger.querySelector("[data-copy-label-text]");
+  if (!(labelNode instanceof HTMLElement)) {
+    return;
+  }
+
+  panel?.querySelectorAll("[data-copy-trigger]").forEach((button) => {
+    button.classList.remove("is-copied");
+    if (!(button instanceof HTMLElement)) {
+      return;
+    }
+    const textNode = button.querySelector("[data-copy-label-text]");
+    if (!(textNode instanceof HTMLElement)) {
+      return;
+    }
+    const defaultText = button.dataset.copyDefaultText;
+    if (defaultText) {
+      textNode.textContent = defaultText;
+    }
+  });
+
+  if (!copyTrigger.dataset.copyDefaultText) {
+    copyTrigger.dataset.copyDefaultText = labelNode.textContent || "";
+  }
+  copyTrigger.classList.add("is-copied");
+  labelNode.textContent =
+    copyTrigger.dataset.copySuccessText || "복사됨!";
+  window.clearTimeout(Number(copyTrigger.dataset.resetTimer || 0));
+  const timerId = window.setTimeout(() => {
+    copyTrigger.classList.remove("is-copied");
+    labelNode.textContent = copyTrigger.dataset.copyDefaultText || "";
+  }, 1800);
+  copyTrigger.dataset.resetTimer = String(timerId);
+});
+
+async function writeToClipboard(value) {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(value);
+    return;
+  }
+
+  const fallback = document.createElement("textarea");
+  fallback.value = value;
+  fallback.setAttribute("readonly", "");
+  fallback.style.position = "fixed";
+  fallback.style.top = "-9999px";
+  fallback.style.left = "-9999px";
+  document.body.appendChild(fallback);
+  fallback.select();
+  fallback.setSelectionRange(0, fallback.value.length);
+  const copied = document.execCommand("copy");
+  document.body.removeChild(fallback);
+  if (!copied) {
+    throw new Error("Clipboard copy failed");
+  }
+}
+
+function initializeCodeCopyButtons() {
+  document.querySelectorAll(".codehilite").forEach((block) => {
+    if (!(block instanceof HTMLElement) || block.dataset.copyReady === "true") {
+      return;
+    }
+
+    const codeNode = block.querySelector("code");
+    if (!(codeNode instanceof HTMLElement)) {
+      return;
+    }
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "code-copy-button";
+    button.textContent = "Copy";
+    button.addEventListener("click", async () => {
+      try {
+        await writeToClipboard(codeNode.innerText);
+      } catch {
+        return;
+      }
+
+      const originalText = button.dataset.defaultText || "Copy";
+      button.textContent = "Copied!";
+      window.clearTimeout(Number(button.dataset.resetTimer || 0));
+      const timerId = window.setTimeout(() => {
+        button.textContent = originalText;
+      }, 1600);
+      button.dataset.defaultText = originalText;
+      button.dataset.resetTimer = String(timerId);
+    });
+
+    block.appendChild(button);
+    block.dataset.copyReady = "true";
+  });
+}
+
+function renderMath(root) {
+  if (typeof window.renderMathInElement !== "function") {
+    return;
+  }
+
+  window.renderMathInElement(root, {
+    delimiters: [
+      { left: "$$", right: "$$", display: true },
+      { left: "\\[", right: "\\]", display: true },
+      { left: "$", right: "$", display: false },
+      { left: "\\(", right: "\\)", display: false },
+    ],
+    throwOnError: false,
+  });
+}
+
+function initializeWikiToc() {
+  const tocLinks = Array.from(document.querySelectorAll("[data-toc-link]"));
+  if (!tocLinks.length) {
+    return;
+  }
+
+  const headingMap = new Map();
+  tocLinks.forEach((link) => {
+    const targetId = link.getAttribute("data-toc-target");
+    if (!targetId) {
+      return;
+    }
+    const heading = document.getElementById(targetId);
+    if (!heading) {
+      return;
+    }
+    headingMap.set(targetId, heading);
+  });
+
+  const setActiveLink = (activeId) => {
+    tocLinks.forEach((link) => {
+      const isActive = link.getAttribute("data-toc-target") === activeId;
+      link.classList.toggle("bg-surface-container-high", isActive);
+      link.classList.toggle("text-on-surface", isActive);
+      link.classList.toggle("font-semibold", isActive);
+    });
+  };
+
+  const headingIds = Array.from(headingMap.keys());
+  if (!headingIds.length) {
+    return;
+  }
+  setActiveLink(headingIds[0]);
+
+  if (!("IntersectionObserver" in window)) {
+    return;
+  }
+
+  let activeId = headingIds[0];
+  const observer = new IntersectionObserver(
+    (entries) => {
+      const visibleEntries = entries
+        .filter((entry) => entry.isIntersecting)
+        .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+
+      if (visibleEntries.length) {
+        activeId = visibleEntries[0].target.id;
+        setActiveLink(activeId);
+        return;
+      }
+
+      const passedHeadings = headingIds.filter((id) => {
+        const heading = headingMap.get(id);
+        return heading && heading.getBoundingClientRect().top < 140;
+      });
+      if (passedHeadings.length) {
+        activeId = passedHeadings[passedHeadings.length - 1];
+        setActiveLink(activeId);
+      }
+    },
+    {
+      rootMargin: "-18% 0px -66% 0px",
+      threshold: [0, 1],
+    }
+  );
+
+  headingMap.forEach((heading) => observer.observe(heading));
+}
 
 document.addEventListener("keydown", (event) => {
   if (event.key !== "Escape") {
@@ -183,6 +390,9 @@ async function syncBrowserTimezone() {
 }
 
 void syncBrowserTimezone();
+initializeWikiToc();
+initializeCodeCopyButtons();
+window.addEventListener("load", () => renderMath(document.body));
 
 const flashMessages = document.querySelectorAll(".flash-message");
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -56,6 +56,12 @@
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Manrope:wght@200..800&display=swap"
               rel="stylesheet">
         <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+        <link rel="stylesheet"
+              href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css">
+        <script defer
+                src="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.js"></script>
+        <script defer
+                src="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/contrib/auto-render.min.js"></script>
         <link rel="stylesheet" href="{% static 'css/app.css' %}">
         <noscript>
             <style>

--- a/templates/layouts/app.html
+++ b/templates/layouts/app.html
@@ -8,6 +8,7 @@
                 {% block app_content %}
                 {% endblock app_content %}
             </main>
+            {% include "partials/footer.html" %}
         </div>
     </div>
 {% endblock body %}

--- a/templates/layouts/auth.html
+++ b/templates/layouts/auth.html
@@ -1,30 +1,33 @@
 {% extends "base.html" %}
 {% block body %}
-    <div class="grid min-h-screen lg:grid-cols-[1.05fr_0.95fr]">
-        <section class="relative hidden overflow-hidden bg-stone-950 px-10 py-12 text-stone-100 lg:flex">
-            <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,193,7,0.3),_transparent_32%),radial-gradient(circle_at_bottom_right,_rgba(255,255,255,0.09),_transparent_30%)]">
-            </div>
-            <div class="relative flex max-w-xl flex-col justify-between">
-                <div>
-                    <div class="inline-flex rounded-full border border-white/15 px-4 py-1 text-xs uppercase tracking-[0.3em] text-stone-300">
-                        HiveWiki
-                    </div>
-                    <h1 class="mt-6 font-headline text-5xl font-black tracking-tight">공동체의 질문을 지식 자산으로 연결합니다.</h1>
-                    <p class="mt-6 text-base leading-8 text-stone-300">커뮤니티와 위키를 나누지 않고, 검색과 편집 흐름을 하나의 경험으로 설계하는 기본 레이아웃입니다.</p>
+    <div class="min-h-screen bg-surface">
+        <div class="grid lg:min-h-[calc(100vh-17rem)] lg:grid-cols-[1.05fr_0.95fr]">
+            <section class="relative hidden overflow-hidden bg-stone-950 px-10 py-12 text-stone-100 lg:flex">
+                <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,193,7,0.3),_transparent_32%),radial-gradient(circle_at_bottom_right,_rgba(255,255,255,0.09),_transparent_30%)]">
                 </div>
-                <div class="grid gap-4">
-                    <div class="rounded-[1.75rem] border border-white/10 bg-white/5 p-6">
-                        <div class="text-sm font-semibold text-amber-300">Editorial layout</div>
-                        <p class="mt-3 text-sm leading-7 text-stone-300">온보딩과 인증 화면은 앱 본문과 분리된 분위기로 유지해 진입 경험을 선명하게 만듭니다.</p>
+                <div class="relative flex max-w-xl flex-col justify-between">
+                    <div>
+                        <div class="inline-flex rounded-full border border-white/15 px-4 py-1 text-xs uppercase tracking-[0.3em] text-stone-300">
+                            HiveWiki
+                        </div>
+                        <h1 class="mt-6 font-headline text-5xl font-black tracking-tight">공동체의 질문을 지식 자산으로 연결합니다.</h1>
+                        <p class="mt-6 text-base leading-8 text-stone-300">커뮤니티의 질문과 운영 지식을 한곳에서 쌓고, 찾고, 정리할 수 있는 워크스페이스입니다.</p>
+                    </div>
+                    <div class="grid gap-4">
+                        <div class="rounded-[1.75rem] border border-white/10 bg-white/5 p-6">
+                            <div class="text-sm font-semibold text-amber-300">Workerbees</div>
+                            <p class="mt-3 text-sm leading-7 text-stone-300">계정에 로그인하면 위키, 검색, 커뮤니티를 바로 이어서 사용할 수 있습니다.</p>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </section>
-        <section class="flex items-center justify-center px-6 py-12 lg:px-10">
-            <div class="w-full max-w-md">
-                {% block auth_content %}
-                {% endblock auth_content %}
-            </div>
-        </section>
+            </section>
+            <section class="flex items-center justify-center px-6 py-12 lg:px-10">
+                <div class="w-full max-w-md">
+                    {% block auth_content %}
+                    {% endblock auth_content %}
+                </div>
+            </section>
+        </div>
+        {% include "partials/footer.html" %}
     </div>
 {% endblock body %}

--- a/templates/layouts/public.html
+++ b/templates/layouts/public.html
@@ -11,7 +11,7 @@
                     </div>
                     <div>
                         <div class="font-headline text-xl font-extrabold tracking-tight">HiveWiki</div>
-                        <div class="text-xs uppercase tracking-[0.24em] text-stone-500">Living Archive</div>
+                        <div class="text-xs uppercase tracking-[0.24em] text-stone-500">Workerbees</div>
                     </div>
                 </a>
                 <nav class="flex items-center gap-2">
@@ -40,5 +40,6 @@
             {% block content %}
             {% endblock content %}
         </main>
+        {% include "partials/footer.html" %}
     </div>
 {% endblock body %}

--- a/templates/pages/community/list.html
+++ b/templates/pages/community/list.html
@@ -4,10 +4,10 @@
 {% endblock title %}
 {% block app_content %}
     <section class="mx-auto max-w-7xl space-y-8">
-        {% include "partials/section_header.html" with eyebrow="Community" title="질문과 논의를 모으는 공간" description="커뮤니티 목록 페이지는 공용 포스트 카드와 상단 검색 입력을 그대로 재사용하는 형태로 설계했습니다." %}
+        {% include "partials/section_header.html" with eyebrow="Community" title="질문과 논의" description="운영 이슈, 회고, 질문을 모아보고 필요한 내용을 문서화로 이어갈 수 있습니다." %}
         <div class="grid gap-6 lg:grid-cols-[0.8fr_1.2fr]">
             <div class="space-y-4">
-                {% include "partials/feature_panel.html" with eyebrow="Flow" title="질문에서 문서로" description="논의가 충분히 정리되면 위키 문서로 연결하는 편집 흐름을 전제로 한 기본 사이드 패널입니다." cta_href="/wiki/" cta_label="위키 열기" %}
+                {% include "partials/feature_panel.html" with eyebrow="연결" title="질문에서 문서로" description="반복되는 질문이나 운영 지식은 위키 문서로 정리해 두고 다시 참고할 수 있습니다." cta_href="/wiki/" cta_label="위키 열기" %}
             </div>
             <div class="space-y-5">
                 {% for item in post_items %}

--- a/templates/pages/home/dashboard.html
+++ b/templates/pages/home/dashboard.html
@@ -9,21 +9,21 @@
                 <div class="text-sm font-semibold text-primary">Dashboard</div>
                 <h1 class="mt-2 font-headline text-5xl font-black tracking-tight">오늘의 지식 흐름</h1>
                 <p class="mt-4 max-w-2xl text-sm leading-7 text-on-surface-variant">
-                    로그인 후 메인에서는 검색, 최신 문서, 커뮤니티 진입점을 한 화면에서 확인할 수 있게 배치했습니다.
+                    자주 찾는 문서와 최근 논의를 한 화면에서 확인하고, 바로 검색으로 이어갈 수 있습니다.
                 </p>
                 <div class="mt-8 max-w-2xl">
-                    {% include "partials/search_bar.html" with placeholder="문서, 게시글, 태그를 검색하세요" action="/search/" target="#dashboard-search-results" %}
+                    {% include "partials/search_bar.html" with placeholder="위키 문서를 검색하세요" action="/search/" target="#dashboard-search-results" push_url="false" %}
                 </div>
             </div>
             <div class="grid gap-4">
-                {% include "partials/stat_tile.html" with label="문서" value="128" description="빠르게 탐색할 수 있는 공용 아카이브 수" %}
+                {% include "partials/stat_tile.html" with label="문서" value="128" description="현재 위키에 정리된 문서 수" %}
                 {% include "partials/stat_tile.html" with label="질문" value="42" description="이번 주에 새로 축적된 커뮤니티 스레드 수" %}
                 {% include "partials/stat_tile.html" with label="연결" value="16" description="커뮤니티와 위키 사이의 최신 연결 수" %}
             </div>
         </section>
         <div id="dashboard-search-results"></div>
         <section class="space-y-5">
-            {% include "partials/section_header.html" with eyebrow="Wiki" title="최신 위키" description="재사용 가능한 문서 카드 컴포넌트를 기준으로 최신 문서 영역을 설계했습니다." href="/wiki/" link_text="전체 보기" %}
+            {% include "partials/section_header.html" with eyebrow="Wiki" title="최신 위키" description="최근 업데이트된 문서를 빠르게 훑어볼 수 있습니다." href="/wiki/" link_text="전체 보기" %}
             <div class="grid gap-5 lg:grid-cols-2">
                 {% for item in wiki_items %}
                     {% include "partials/wiki_card.html" %}
@@ -31,7 +31,7 @@
             </div>
         </section>
         <section class="space-y-5">
-            {% include "partials/section_header.html" with eyebrow="Community" title="최신 커뮤니티 글" description="질문, 회고, 공지처럼 서로 다른 성격의 글도 같은 카드 규칙으로 다룰 수 있게 구성했습니다." href="/community/" link_text="전체 보기" %}
+            {% include "partials/section_header.html" with eyebrow="Community" title="최신 커뮤니티 글" description="최근 올라온 질문과 논의를 확인하고 필요한 문서를 찾아보세요." href="/community/" link_text="전체 보기" %}
             <div class="space-y-5">
                 {% for item in post_items %}
                     {% include "partials/post_card.html" %}

--- a/templates/pages/home/public_main.html
+++ b/templates/pages/home/public_main.html
@@ -7,13 +7,13 @@
         <div class="grid gap-12 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
             <div>
                 <div class="inline-flex rounded-full bg-secondary-container px-3 py-1 text-xs font-bold text-on-secondary-container">
-                    Foundation Layout
+                    Workerbees Wiki
                 </div>
                 <h1 class="mt-6 max-w-4xl font-headline text-5xl font-black tracking-tight text-on-surface lg:text-7xl">
                     학교 공동체의 질문과 문서를 하나의 흐름으로 엮습니다.
                 </h1>
                 <p class="mt-6 max-w-2xl text-base leading-8 text-on-surface-variant lg:text-lg">
-                    커뮤니티에서 나온 문제의식이 위키 문서로 정리되고, 다시 검색과 탐색 경험으로 이어지는 구조를 기본 화면에 반영했습니다.
+                    흩어진 질문과 답변을 문서로 정리하고, 다시 검색 가능한 지식으로 연결합니다.
                 </p>
                 <div class="mt-8 flex flex-wrap gap-3">
                     <a href="{% url 'signup' %}"
@@ -22,12 +22,12 @@
                        class="rounded-xl bg-surface-container-low px-5 py-3 text-sm font-semibold text-primary">검색 먼저 보기</a>
                 </div>
                 <div class="mt-10 max-w-2xl">
-                    {% include "partials/search_bar.html" with placeholder="궁금한 문서나 게시글을 검색해보세요" action="/search/" target="#preview-results" %}
+                    {% include "partials/search_bar.html" with placeholder="궁금한 위키 문서를 검색해보세요" action="/search/" target="#preview-results" push_url="false" %}
                 </div>
                 <div id="preview-results" class="mt-6"></div>
             </div>
             <div class="grid gap-5">
-                {% include "partials/feature_panel.html" with eyebrow="Editorial Surface" title="Warm surface, honey accent, no-line spacing" description="초안의 톤을 유지하면서 랜딩 상단에 강한 소개 영역을 두고, 오른쪽에는 실제 카드 컴포넌트를 배치했습니다." cta_href="/search/" cta_label="검색 레이아웃 보기" %}
+                {% include "partials/feature_panel.html" with eyebrow="Explore" title="문서와 질문을 함께 탐색하세요" description="최근 문서와 커뮤니티 흐름을 함께 보면서 필요한 정보를 더 빠르게 찾을 수 있습니다." cta_href="/search/" cta_label="통합 검색 보기" %}
                 <div class="grid gap-4 rounded-[2rem] bg-surface-container-low p-6 lg:p-7">
                     {% include "partials/wiki_card.html" with item=featured_wiki %}
                     {% include "partials/post_card.html" with item=featured_post %}

--- a/templates/pages/search/results.html
+++ b/templates/pages/search/results.html
@@ -4,12 +4,10 @@
 {% endblock title %}
 {% block app_content %}
     <section class="mx-auto max-w-7xl space-y-8">
-        {% include "partials/section_header.html" with eyebrow="Search" title="통합 검색 결과" description="문서와 게시글을 한 화면에서 비교할 수 있는 기본 결과 레이아웃입니다." %}
-        {% if query %}
-            <div class="rounded-2xl bg-surface-container-low px-5 py-4 text-sm text-on-surface-variant">
-                검색어: <span class="font-semibold text-on-surface">{{ query }}</span>
-            </div>
-        {% endif %}
-        {% include "partials/search_results.html" %}
+        {% include "partials/section_header.html" with eyebrow="Search" title="문서 검색" description="현재는 위키 문서를 기준으로 검색 결과를 보여줍니다." %}
+        <div class="max-w-3xl">
+            {% include "partials/search_bar.html" with placeholder="찾고 싶은 위키 문서를 검색하세요" action="/search/" value=query %}
+        </div>
+        {% include "partials/global_search_results.html" %}
     </section>
 {% endblock app_content %}

--- a/templates/pages/wiki/detail.html
+++ b/templates/pages/wiki/detail.html
@@ -1,5 +1,4 @@
 {% extends "layouts/app.html" %}
-{% load markdown_extras %}
 {% block title %}
     HiveWiki | {{ document.title }}
 {% endblock title %}
@@ -89,7 +88,7 @@
                 <textarea id="agent-copy" hidden readonly>{{ copy_agent_text }}</textarea>
                 {% if revision %}
                     <article class="reading-prose prose prose-stone mt-8 max-w-none leading-8 text-on-surface">
-                        {{ display_markdown|render_markdown }}
+                        {{ rendered_markdown|safe }}
                     </article>
                 {% else %}
                     {% include "partials/empty_state.html" with title="표시할 리비전이 없습니다" description="현재 문서에 연결된 최신 리비전이 없습니다." %}
@@ -103,10 +102,9 @@
                                 {% for item in toc_items %}
                                     <li>
                                         <a href="#{{ item.id }}"
-                                           class="block rounded-xl px-3 py-2 transition hover:bg-surface-container-high hover:text-on-surface"
+                                           class="block rounded-xl px-3 py-2 transition hover:bg-surface-container-high hover:text-on-surface {% if item.toc_level == 1 %}pl-3{% elif item.toc_level == 2 %}pl-4{% elif item.toc_level == 3 %}pl-6{% elif item.toc_level == 4 %}pl-8{% elif item.toc_level == 5 %}pl-10{% else %}pl-12{% endif %}"
                                            data-toc-link
-                                           data-toc-target="{{ item.id }}"
-                                           style="padding-left: {% if item.toc_level == 1 %}0.75{% elif item.toc_level == 2 %}1{% elif item.toc_level == 3 %}1.5{% elif item.toc_level == 4 %}2{% elif item.toc_level == 5 %}2.5{% else %}3{% endif %}rem">
+                                           data-toc-target="{{ item.id }}">
                                             <span class="inline-flex min-w-[2.25rem] text-stone-400">{{ item.label }}</span>
                                             <span>{{ item.text }}</span>
                                         </a>

--- a/templates/pages/wiki/detail.html
+++ b/templates/pages/wiki/detail.html
@@ -1,0 +1,123 @@
+{% extends "layouts/app.html" %}
+{% load markdown_extras %}
+{% block title %}
+    HiveWiki | {{ document.title }}
+{% endblock title %}
+{% block app_content %}
+    <section class="mx-auto max-w-7xl space-y-8">
+        {% include "partials/section_header.html" with eyebrow="Wiki" title=document.title description=document.summary href="/wiki/" link_text="목록으로" %}
+        <div class="grid gap-6 xl:grid-cols-[minmax(0,1fr)_18rem]">
+            <div class="rounded-[2rem] bg-surface-container-low p-8">
+                <div class="flex flex-wrap items-center justify-between gap-4 border-b border-outline-variant/70 pb-6">
+                    <div class="flex flex-wrap items-center gap-3 text-sm text-on-surface-variant">
+                        <span class="rounded-full bg-secondary-container px-3 py-1 font-semibold text-on-secondary-container">문서</span>
+                        <span>업데이트</span>
+                        <span class="timezone-sensitive"
+                              data-local-datetime="{{ document.updated_at|date:'c' }}"
+                              data-local-format="datetime">{{ document.updated_at|date:"Y.m.d H:i" }}</span>
+                    </div>
+                    <div class="wiki-actions-panel flex flex-wrap items-center gap-2">
+                        <span class="sr-only">문서 액션</span>
+                        <button type="button"
+                                class="inline-flex min-w-[9.75rem] items-center justify-center rounded-full bg-surface-container-high px-4 py-2.5 text-sm font-semibold text-on-surface transition hover:-translate-y-0.5 hover:bg-surface-container-highest"
+                                data-copy-trigger
+                                data-copy-label="공유 링크"
+                                data-copy-source="share-url-copy"
+                                data-copy-success-text="링크 복사됨!">
+                            <span class="inline-flex items-center gap-2">
+                                <svg class="h-4 w-4 text-on-surface-variant"
+                                     viewBox="0 0 24 24"
+                                     fill="none"
+                                     stroke="currentColor"
+                                     stroke-width="2"
+                                     stroke-linecap="round"
+                                     stroke-linejoin="round"
+                                     aria-hidden="true">
+                                    <path d="M10 13a5 5 0 0 0 7.07 0l1.41-1.41a5 5 0 0 0-7.07-7.07L10 5" />
+                                    <path d="M14 11a5 5 0 0 0-7.07 0l-1.41 1.41a5 5 0 0 0 7.07 7.07L14 19" />
+                                </svg>
+                                <span class="inline-block w-[6.25rem] text-left" data-copy-label-text>문서 공유</span>
+                            </span>
+                        </button>
+                        <button type="button"
+                                class="inline-flex min-w-[10.75rem] items-center justify-center rounded-full bg-surface-container-high px-4 py-2.5 text-sm font-semibold text-on-surface transition hover:-translate-y-0.5 hover:bg-surface-container-highest"
+                                data-copy-trigger
+                                data-copy-label="읽기용 사본"
+                                data-copy-source="human-copy"
+                                data-copy-success-text="읽기용 복사됨!">
+                            <span class="inline-flex items-center gap-2">
+                                <svg class="h-4 w-4 text-on-surface-variant"
+                                     viewBox="0 0 24 24"
+                                     fill="none"
+                                     stroke="currentColor"
+                                     stroke-width="2"
+                                     stroke-linecap="round"
+                                     stroke-linejoin="round"
+                                     aria-hidden="true">
+                                    <path d="M6 4.5h12a1.5 1.5 0 0 1 1.5 1.5v11.5H8a2.5 2.5 0 0 0-2.5 2.5V6A1.5 1.5 0 0 1 7 4.5" />
+                                    <path d="M8 17.5h11.5" />
+                                </svg>
+                                <span class="inline-block w-[7.25rem] text-left" data-copy-label-text>읽기용 복사</span>
+                            </span>
+                        </button>
+                        <button type="button"
+                                class="inline-flex min-w-[12.25rem] items-center justify-center rounded-full bg-stone-950 px-4 py-2.5 text-sm font-semibold text-stone-50 transition hover:-translate-y-0.5 hover:bg-stone-800"
+                                data-copy-trigger
+                                data-copy-label="에이전트용 사본"
+                                data-copy-source="agent-copy"
+                                data-copy-success-text="에이전트용 복사됨!">
+                            <span class="inline-flex items-center gap-2">
+                                <svg class="h-4 w-4 text-stone-300"
+                                     viewBox="0 0 24 24"
+                                     fill="none"
+                                     stroke="currentColor"
+                                     stroke-width="2"
+                                     stroke-linecap="round"
+                                     stroke-linejoin="round"
+                                     aria-hidden="true">
+                                    <rect x="5" y="3.5" width="14" height="17" rx="2.5" />
+                                    <path d="M9 3.5h6" />
+                                    <path d="M9 11.5l2 2 4-4" />
+                                </svg>
+                                <span class="inline-block w-[8.75rem] text-left" data-copy-label-text>에이전트용 복사</span>
+                            </span>
+                        </button>
+                    </div>
+                </div>
+                <textarea id="share-url-copy" hidden readonly>{{ share_url }}</textarea>
+                <textarea id="human-copy" hidden readonly>{{ copy_human_text }}</textarea>
+                <textarea id="agent-copy" hidden readonly>{{ copy_agent_text }}</textarea>
+                {% if revision %}
+                    <article class="reading-prose prose prose-stone mt-8 max-w-none leading-8 text-on-surface">
+                        {{ display_markdown|render_markdown }}
+                    </article>
+                {% else %}
+                    {% include "partials/empty_state.html" with title="표시할 리비전이 없습니다" description="현재 문서에 연결된 최신 리비전이 없습니다." %}
+                {% endif %}
+            </div>
+            {% if toc_items %}
+                <aside class="hidden xl:block">
+                    <div class="sticky top-28 rounded-[1.5rem] bg-surface-container-low p-5">
+                        <nav data-toc-nav>
+                            <ul class="space-y-2 text-sm text-on-surface-variant">
+                                {% for item in toc_items %}
+                                    <li>
+                                        <a href="#{{ item.id }}"
+                                           class="block rounded-xl px-3 py-2 transition hover:bg-surface-container-high hover:text-on-surface"
+                                           data-toc-link
+                                           data-toc-target="{{ item.id }}"
+                                           style="padding-left: {% if item.toc_level == 1 %}0.75{% elif item.toc_level == 2 %}1{% elif item.toc_level == 3 %}1.5{% elif item.toc_level == 4 %}2{% elif item.toc_level == 5 %}2.5{% else %}3{% endif %}rem">
+                                            <span class="inline-flex min-w-[2.25rem] text-stone-400">{{ item.label }}</span>
+                                            <span>{{ item.text }}</span>
+                                        </a>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </nav>
+                    </div>
+                </aside>
+            {% endif %}
+        </div>
+    </section>
+    {% include "partials/wiki_write_fab.html" %}
+{% endblock app_content %}

--- a/templates/pages/wiki/search_home.html
+++ b/templates/pages/wiki/search_home.html
@@ -4,21 +4,17 @@
 {% endblock title %}
 {% block app_content %}
     <section class="mx-auto max-w-7xl space-y-8">
-        {% include "partials/section_header.html" with eyebrow="Wiki" title="지식 탐색의 시작점" description="위키 첫 화면은 검색 입력과 큐레이션 카드가 중심이 되도록 설계했습니다." %}
+        {% include "partials/section_header.html" with eyebrow="Wiki" title="위키 둘러보기" description="주제나 키워드로 문서를 찾고, 최근 정리된 내용을 바로 확인할 수 있습니다." %}
         <div class="rounded-[2rem] bg-surface-container-low p-8">
             <h2 class="font-headline text-4xl font-black tracking-tight">찾고 싶은 문서를 바로 검색하세요</h2>
             <p class="mt-3 max-w-2xl text-sm leading-7 text-on-surface-variant">
-                태그, 키워드, 커뮤니티 질문을 기준으로 바로 탐색을 시작할 수 있게 기본 검색 영역을 크게 배치했습니다.
+                운영 기록, 수업 정보, 개발 메모처럼 반복해서 찾게 되는 내용을 빠르게 검색해보세요.
             </p>
             <div class="mt-8 max-w-3xl">
-                {% include "partials/search_bar.html" with placeholder="운영, 수업, 개발, 회고를 검색하세요" action="/search/" target="#wiki-search-results" %}
+                {% include "partials/search_bar.html" with placeholder="운영, 수업, 개발, 회고를 검색하세요" action="/wiki/" target="#wiki-search-results" push_url="false" value=query %}
             </div>
-            <div id="wiki-search-results" class="mt-6"></div>
-        </div>
-        <div class="grid gap-5 lg:grid-cols-2">
-            {% for item in wiki_items %}
-                {% include "partials/wiki_card.html" %}
-            {% endfor %}
+            <div id="wiki-search-results" class="mt-6">{% include "partials/wiki_search_results.html" %}</div>
         </div>
     </section>
+    {% include "partials/wiki_write_fab.html" %}
 {% endblock app_content %}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -1,0 +1,18 @@
+<footer class="border-t border-stone-200/70 bg-surface-container-low">
+    <div class="mx-auto flex max-w-7xl flex-col gap-4 px-6 py-6 text-sm text-on-surface-variant lg:flex-row lg:items-center lg:justify-between lg:px-10">
+        <div class="flex items-center gap-3">
+            <span class="flex h-8 w-8 items-center justify-center rounded-full bg-stone-950 text-xs font-black text-white">W</span>
+            <span class="font-semibold text-on-surface">Workerbees</span>
+            <span class="text-stone-400">·</span>
+            <span>HiveWiki</span>
+        </div>
+        <div class="flex flex-wrap items-center gap-4 text-sm">
+            <a href="{% if current_user %}{% url 'wiki_home' %}{% else %}{% url 'login' %}?next=/wiki/{% endif %}"
+               class="transition hover:text-on-surface">위키</a>
+            <a href="{% if current_user %}{% url 'community_list' %}{% else %}{% url 'login' %}?next=/community/{% endif %}"
+               class="transition hover:text-on-surface">커뮤니티</a>
+            <a href="{% url 'integrated_search' %}"
+               class="transition hover:text-on-surface">검색</a>
+        </div>
+    </div>
+</footer>

--- a/templates/partials/global_search_results.html
+++ b/templates/partials/global_search_results.html
@@ -1,0 +1,37 @@
+<div class="space-y-6">
+    {% if query %}
+        <div class="rounded-[1.75rem] bg-surface-container-low px-5 py-4 text-sm text-on-surface-variant">
+            <span>검색어</span>
+            <span class="ml-2 font-semibold text-on-surface">{{ query }}</span>
+            <span class="ml-3 text-stone-400">문서 {{ wiki_result_count }}건</span>
+        </div>
+    {% endif %}
+    <section class="space-y-4">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+            <div>
+                <h3 class="font-headline text-2xl font-extrabold tracking-tight">위키 문서</h3>
+                <p class="mt-2 text-sm leading-7 text-on-surface-variant">
+                    {% if query %}
+                        제목, 요약, 본문에서 일치하는 결과입니다.
+                    {% else %}
+                        최근 업데이트된 문서를 둘러보고, 필요한 경우 바로 검색으로 좁혀갈 수 있습니다.
+                    {% endif %}
+                </p>
+            </div>
+            <div class="rounded-full bg-surface-container-high px-4 py-2 text-sm font-semibold text-on-surface-variant">
+                {{ wiki_result_count }}건
+            </div>
+        </div>
+        {% if wiki_items %}
+            <div class="grid gap-5 lg:grid-cols-2">
+                {% for item in wiki_items %}
+                    {% include "partials/wiki_card.html" %}
+                {% endfor %}
+            </div>
+        {% elif query %}
+            {% include "partials/empty_state.html" with title="검색 결과가 없습니다" description="검색어를 바꾸거나 더 일반적인 표현으로 다시 시도해 보세요." %}
+        {% else %}
+            {% include "partials/empty_state.html" with title="최근 문서가 없습니다" description="문서가 쌓이면 이곳에서 최근 업데이트 항목을 바로 확인할 수 있습니다." %}
+        {% endif %}
+    </section>
+</div>

--- a/templates/partials/global_search_results.html
+++ b/templates/partials/global_search_results.html
@@ -1,37 +1,41 @@
 <div class="space-y-6">
-    {% if query %}
-        <div class="rounded-[1.75rem] bg-surface-container-low px-5 py-4 text-sm text-on-surface-variant">
-            <span>검색어</span>
-            <span class="ml-2 font-semibold text-on-surface">{{ query }}</span>
-            <span class="ml-3 text-stone-400">문서 {{ wiki_result_count }}건</span>
-        </div>
-    {% endif %}
-    <section class="space-y-4">
-        <div class="flex flex-wrap items-center justify-between gap-3">
-            <div>
-                <h3 class="font-headline text-2xl font-extrabold tracking-tight">위키 문서</h3>
-                <p class="mt-2 text-sm leading-7 text-on-surface-variant">
-                    {% if query %}
-                        제목, 요약, 본문에서 일치하는 결과입니다.
-                    {% else %}
-                        최근 업데이트된 문서를 둘러보고, 필요한 경우 바로 검색으로 좁혀갈 수 있습니다.
-                    {% endif %}
-                </p>
+    {% if show_blank_query_state %}
+        {% include "partials/empty_state.html" with title="검색어를 입력해 주세요" description="찾고 싶은 문서 제목, 요약, 본문 키워드를 입력하면 결과를 바로 보여줍니다." %}
+    {% else %}
+        {% if query %}
+            <div class="rounded-[1.75rem] bg-surface-container-low px-5 py-4 text-sm text-on-surface-variant">
+                <span>검색어</span>
+                <span class="ml-2 font-semibold text-on-surface">{{ query }}</span>
+                <span class="ml-3 text-stone-400">문서 {{ wiki_result_count }}건</span>
             </div>
-            <div class="rounded-full bg-surface-container-high px-4 py-2 text-sm font-semibold text-on-surface-variant">
-                {{ wiki_result_count }}건
-            </div>
-        </div>
-        {% if wiki_items %}
-            <div class="grid gap-5 lg:grid-cols-2">
-                {% for item in wiki_items %}
-                    {% include "partials/wiki_card.html" %}
-                {% endfor %}
-            </div>
-        {% elif query %}
-            {% include "partials/empty_state.html" with title="검색 결과가 없습니다" description="검색어를 바꾸거나 더 일반적인 표현으로 다시 시도해 보세요." %}
-        {% else %}
-            {% include "partials/empty_state.html" with title="최근 문서가 없습니다" description="문서가 쌓이면 이곳에서 최근 업데이트 항목을 바로 확인할 수 있습니다." %}
         {% endif %}
-    </section>
+        <section class="space-y-4">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                    <h3 class="font-headline text-2xl font-extrabold tracking-tight">위키 문서</h3>
+                    <p class="mt-2 text-sm leading-7 text-on-surface-variant">
+                        {% if query %}
+                            제목, 요약, 본문에서 일치하는 결과입니다.
+                        {% else %}
+                            최근 업데이트된 문서를 둘러보고, 필요한 경우 바로 검색으로 좁혀갈 수 있습니다.
+                        {% endif %}
+                    </p>
+                </div>
+                <div class="rounded-full bg-surface-container-high px-4 py-2 text-sm font-semibold text-on-surface-variant">
+                    {{ wiki_result_count }}건
+                </div>
+            </div>
+            {% if wiki_items %}
+                <div class="grid gap-5 lg:grid-cols-2">
+                    {% for item in wiki_items %}
+                        {% include "partials/wiki_card.html" %}
+                    {% endfor %}
+                </div>
+            {% elif query %}
+                {% include "partials/empty_state.html" with title="검색 결과가 없습니다" description="검색어를 바꾸거나 더 일반적인 표현으로 다시 시도해 보세요." %}
+            {% else %}
+                {% include "partials/empty_state.html" with title="최근 문서가 없습니다" description="문서가 쌓이면 이곳에서 최근 업데이트 항목을 바로 확인할 수 있습니다." %}
+            {% endif %}
+        </section>
+    {% endif %}
 </div>

--- a/templates/partials/post_card.html
+++ b/templates/partials/post_card.html
@@ -9,7 +9,7 @@
             <a href="{{ item.url|default:'#' }}"
                class="font-headline text-2xl font-extrabold tracking-tight">{{ item.title|default:"게시글 제목" }}</a>
             <p class="mt-3 line-clamp-3 text-sm leading-7 text-on-surface-variant">
-                {{ item.summary|default:"본문 일부가 미리보기 형태로 노출됩니다. 목록, 검색 결과, 관련 게시글에서 재사용합니다." }}
+                {{ item.summary|default:"게시글 요약이 아직 없습니다." }}
             </p>
         </div>
         <span class="shrink-0 rounded-full bg-surface-container-low px-3 py-1 text-xs font-semibold text-primary">{{ item.comment_count|default:"12" }} comments</span>

--- a/templates/partials/search_bar.html
+++ b/templates/partials/search_bar.html
@@ -6,7 +6,7 @@
         <span class="text-stone-400">⌕</span>
         <input type="text"
                name="q"
-               value="{{ value|default:query|default:'' }}"
+               value="{% firstof value query '' %}"
                placeholder="{{ placeholder|default:'검색어를 입력하세요' }}"
                class="w-full border-0 bg-transparent p-0 text-sm text-on-surface placeholder:text-stone-400 focus:ring-0">
     </div>

--- a/templates/partials/search_bar.html
+++ b/templates/partials/search_bar.html
@@ -1,15 +1,12 @@
 <form action="{{ action|default:'/search/' }}"
       method="get"
       class="w-full"
-      hx-get="{{ action|default:'/search/' }}"
-      hx-target="{{ target|default:'#search-results' }}"
-      hx-trigger="keyup changed delay:300ms from:input, submit"
-      hx-push-url="true">
+      {% if target %} hx-get="{{ action|default:'/search/' }}" hx-target="{{ target }}" hx-trigger="input delay:300ms from:input, search from:input, submit" hx-push-url="{{ push_url|default:'true' }}" {% endif %}>
     <div class="ambient-shadow flex items-center gap-3 rounded-[1.5rem] border border-stone-200/70 bg-surface-container-lowest px-4 py-3">
         <span class="text-stone-400">⌕</span>
         <input type="text"
                name="q"
-               value="{{ request.GET.q }}"
+               value="{{ value|default:query|default:'' }}"
                placeholder="{{ placeholder|default:'검색어를 입력하세요' }}"
                class="w-full border-0 bg-transparent p-0 text-sm text-on-surface placeholder:text-stone-400 focus:ring-0">
     </div>

--- a/templates/partials/sidebar.html
+++ b/templates/partials/sidebar.html
@@ -48,9 +48,9 @@
                 </form>
             </div>
         {% else %}
-            <div class="text-xs uppercase tracking-[0.28em] text-stone-400">Foundation</div>
-            <h2 class="mt-3 font-headline text-2xl font-extrabold tracking-tight">Shared UI Kit</h2>
-            <p class="mt-3 text-sm leading-7 text-stone-300">검색 바, 카드, 비주얼 섹션, 요약 블록을 공통 partial로 먼저 고정했습니다.</p>
+            <div class="text-xs uppercase tracking-[0.28em] text-stone-400">Workspace</div>
+            <h2 class="mt-3 font-headline text-2xl font-extrabold tracking-tight">HiveWiki</h2>
+            <p class="mt-3 text-sm leading-7 text-stone-300">로그인하면 위키 탐색, 커뮤니티 확인, 검색 기능을 바로 사용할 수 있습니다.</p>
         {% endif %}
     </div>
 </aside>

--- a/templates/partials/topbar.html
+++ b/templates/partials/topbar.html
@@ -5,7 +5,7 @@
             <div class="font-headline text-xl font-extrabold tracking-tight">{{ page_heading|default:"Dashboard" }}</div>
         </div>
         <div class="hidden items-center gap-4 md:flex">
-            {% include "partials/search_bar.html" with placeholder="지식과 게시글을 검색하세요" action=search_action|default:"/search/" target=search_target|default:"#global-search-results" %}
+            {% include "partials/search_bar.html" with placeholder="위키 문서를 검색하세요" action=search_action|default:"/search/" %}
             {% if current_user %}
                 <a href="{% url 'mypage' %}"
                    class="rounded-2xl bg-surface-container-low px-4 py-3 text-sm font-semibold text-on-surface-variant">{{ current_user.username }}</a>

--- a/templates/partials/wiki_card.html
+++ b/templates/partials/wiki_card.html
@@ -1,13 +1,11 @@
 <article class="rounded-[1.75rem] bg-surface-container-lowest p-6 ambient-shadow transition hover:-translate-y-0.5 hover:bg-surface-container-high">
     <div class="mb-3 flex items-center gap-2 text-xs">
         <span class="rounded-full bg-secondary-container px-2 py-1 font-bold text-on-secondary-container">{{ item.category|default:"문서" }}</span>
-        <span class="text-stone-400">{{ item.updated_at|default:"방금 전" }}</span>
+        <span class="text-stone-400">{{ item.updated_at|date:"Y-m-d H:i"|default:"방금 전" }}</span>
     </div>
     <a href="{{ item.url|default:'#' }}"
        class="block font-headline text-2xl font-extrabold tracking-tight text-on-surface">{{ item.title|default:"문서 제목" }}</a>
-    <p class="mt-3 line-clamp-3 text-sm leading-7 text-on-surface-variant">
-        {{ item.summary|default:"문서 요약이 들어갑니다. 검색 결과와 최신 문서 영역에서 공통 재사용되는 카드입니다." }}
-    </p>
+    <p class="mt-3 line-clamp-3 text-sm leading-7 text-on-surface-variant">{{ item.summary|default:"문서 요약이 아직 없습니다." }}</p>
     <div class="mt-5 flex flex-wrap gap-2">
         {% for tag in item.tags|default:list_tags %}
             <span class="rounded-full bg-surface-container-low px-3 py-1 text-xs font-medium text-on-surface-variant">{{ tag }}</span>

--- a/templates/partials/wiki_search_results.html
+++ b/templates/partials/wiki_search_results.html
@@ -1,0 +1,32 @@
+<div class="space-y-5">
+    <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+            <h3 class="font-headline text-2xl font-extrabold tracking-tight">
+                {% if query %}
+                    "{{ query }}" 검색 결과
+                {% else %}
+                    최근 문서
+                {% endif %}
+            </h3>
+            <p class="mt-2 text-sm leading-7 text-on-surface-variant">
+                {% if query %}
+                    제목, 요약, 본문에서 일치하는 문서를 보여줍니다.
+                {% else %}
+                    최근 업데이트된 위키 문서를 확인할 수 있습니다.
+                {% endif %}
+            </p>
+        </div>
+        <div class="rounded-full bg-surface-container-high px-4 py-2 text-sm font-semibold text-on-surface-variant">
+            {{ wiki_result_count }}건
+        </div>
+    </div>
+    {% if wiki_items %}
+        <div class="grid gap-5 lg:grid-cols-2">
+            {% for item in wiki_items %}
+                {% include "partials/wiki_card.html" %}
+            {% endfor %}
+        </div>
+    {% else %}
+        {% include "partials/empty_state.html" with title="문서를 찾지 못했습니다" description="다른 키워드나 더 짧은 검색어로 다시 시도해 보세요." %}
+    {% endif %}
+</div>

--- a/templates/partials/wiki_write_fab.html
+++ b/templates/partials/wiki_write_fab.html
@@ -1,0 +1,23 @@
+<div class="pointer-events-none fixed bottom-6 right-6 z-30 lg:bottom-8 lg:right-10">
+    <button type="button"
+            aria-disabled="true"
+            class="pointer-events-auto inline-flex items-center gap-3 rounded-full bg-stone-950 px-5 py-4 text-sm font-semibold text-stone-50 shadow-[0_18px_40px_rgba(28,25,23,0.18)] transition">
+        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-white/10">
+            <svg class="h-5 w-5"
+                 viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 stroke-width="2"
+                 stroke-linecap="round"
+                 stroke-linejoin="round"
+                 aria-hidden="true">
+                <path d="M12 20h9" />
+                <path d="M16.5 3.5a2.12 2.12 0 1 1 3 3L7 19l-4 1 1-4Z" />
+            </svg>
+        </span>
+        <span class="flex flex-col items-start leading-tight">
+            <span>글쓰기</span>
+            <span class="text-xs font-medium text-stone-300">준비 중</span>
+        </span>
+    </button>
+</div>

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,18 @@ wheels = [
 ]
 
 [[package]]
+name = "bleach"
+version = "6.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl", hash = "sha256:fe10ec77c93ddf3d13a73b035abaac7a9f5e436513864ccdad516693213c65d6", size = 164437, upload-time = "2025-10-27T17:57:37.538Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -135,12 +147,17 @@ name = "hivewiki-web"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "bleach" },
     { name = "django" },
     { name = "django-environ" },
     { name = "django-htmx" },
     { name = "django-redis" },
     { name = "django-tailwind" },
+    { name = "markdown" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "tinycss2" },
     { name = "uvicorn" },
     { name = "whitenoise" },
 ]
@@ -152,12 +169,17 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "bleach", specifier = ">=6.2.0,<7.0" },
     { name = "django", specifier = ">=5.2.13,<6.0" },
     { name = "django-environ", specifier = ">=0.13.0" },
     { name = "django-htmx", specifier = ">=1.27.0" },
     { name = "django-redis", specifier = ">=6.0.0" },
     { name = "django-tailwind", specifier = ">=4.4.2" },
+    { name = "markdown", specifier = ">=3.9,<4.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
+    { name = "pygments", specifier = ">=2.19.0,<3.0" },
+    { name = "pymdown-extensions", specifier = ">=10.16.0,<11.0" },
+    { name = "tinycss2", specifier = ">=1.4.0,<2.0" },
     { name = "uvicorn", specifier = ">=0.42.0" },
     { name = "whitenoise", specifier = ">=6.12.0" },
 ]
@@ -172,6 +194,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/84/376a3b96e5a8d33a7aa2c5b3b31a4b3c364117184bf0b17418055f6ace66/identify-2.6.17.tar.gz", hash = "sha256:f816b0b596b204c9fdf076ded172322f2723cf958d02f9c3587504834c8ff04d", size = 99579, upload-time = "2026-03-01T20:04:12.702Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/66/71c1227dff78aaeb942fed29dd5651f2aec166cc7c9aeea3e8b26a539b7d/identify-2.6.17-py2.py3-none-any.whl", hash = "sha256:be5f8412d5ed4b20f2bd41a65f920990bdccaa6a4a18a08f1eefdcd0bdd885f0", size = 99382, upload-time = "2026-03-01T20:04:11.439Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
 ]
 
 [[package]]
@@ -245,6 +276,28 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "10.21.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
 name = "pytailwindcss"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -303,6 +356,18 @@ wheels = [
 ]
 
 [[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -346,6 +411,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2f/c9/18d4b36606d6091844daa3bd93cf7dc78e6f5da21d9f21d06c221104b684/virtualenv-21.1.0.tar.gz", hash = "sha256:1990a0188c8f16b6b9cf65c9183049007375b26aad415514d377ccacf1e4fb44", size = 5840471, upload-time = "2026-02-27T08:49:29.702Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/55/896b06bf93a49bec0f4ae2a6f1ed12bd05c8860744ac3a70eda041064e4d/virtualenv-21.1.0-py3-none-any.whl", hash = "sha256:164f5e14c5587d170cf98e60378eb91ea35bf037be313811905d3a24ea33cc07", size = 5825072, upload-time = "2026-02-27T08:49:27.516Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add public wiki document browsing with markdown detail pages, TOC, copy actions, and a floating write CTA
- add wiki seed data, markdown rendering enhancements, and a simplified global footer
- restructure search into a wiki-focused exploration flow with dedicated search helpers and tests

## Testing
- python manage.py test apps.core.tests.test_search_views apps.core.tests.test_wiki_views
- python manage.py check
- pre-commit run --files apps/core/search.py apps/core/views.py apps/core/tests/test_search_views.py apps/core/tests/test_wiki_views.py templates/partials/search_bar.html templates/partials/topbar.html templates/pages/wiki/search_home.html templates/pages/search/results.html templates/partials/wiki_search_results.html templates/partials/global_search_results.html templates/pages/home/public_main.html templates/pages/home/dashboard.html templates/partials/footer.html


위키 페이지 문서 화면 예시 스크린샷

<img width="2607" height="1618" alt="image" src="https://github.com/user-attachments/assets/3097dfbc-f0fe-4c60-8895-2f7e97f3c114" />

---

<img width="1810" height="1584" alt="image" src="https://github.com/user-attachments/assets/71911bbf-4a63-4764-aa24-e961b2d7e69d" />

---

<img width="3231" height="1822" alt="image" src="https://github.com/user-attachments/assets/6254a49d-1d84-495c-a77d-98fe8f83fafb" />


---

<img width="2565" height="1284" alt="image" src="https://github.com/user-attachments/assets/ae1ff8ca-ace8-4cb4-959b-bda3d6362670" />
