### PR TITLE
feat: add health probes and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HiveWiki Web
 
 HiveWiki Web은 HiveWiki 프로젝트의 웹 애플리케이션입니다.  
-**Django** 기반으로 개발되며 **HTMX**, **Alpine.js**, **TailwindCSS**를 활용한 서버 렌더링 중심 구조를 목표로 합니다.
+**Django** 기반으로 개발되며 **htmx**, **Tailwind CSS**, 그리고 최소한의 커스텀 JavaScript를 활용한 서버 렌더링 중심 구조를 목표로 합니다.
 
 ## 개발 환경
 
@@ -35,10 +35,11 @@ hivewiki-web/
       views.py
   config/
     settings.py            # Django 설정, .env 로딩, 보안/세션/캐시 설정
-    urls.py                # 루트 URL 라우팅
+    urls.py                # 루트 URL 라우팅 및 운영 엔드포인트
+    observability.py       # liveness/readiness probe, Prometheus metrics
   static/
     css/app.css            # 공용 스타일
-    js/app.js              # 최소 클라이언트 스크립트
+    js/app.js              # 최소 클라이언트 스크립트와 timezone 동기화
   templates/
     layouts/               # public/app/auth 레이아웃
     pages/                 # 페이지 템플릿
@@ -57,12 +58,22 @@ cp .env.example .env
 uv run pre-commit install --hook-type pre-commit --hook-type commit-msg
 ```
 
+이 저장소에서는 `nix develop --command ...` 실행도 지원하며, 로컬 도구 버전을 맞춰야 할 때 권장합니다.
+
 로컬 PostgreSQL과 Valkey가 실행 중이라면 아래 명령으로 기본 검증과 서버 실행이 가능합니다.
 
 ```bash
 UV_CACHE_DIR=/tmp/hivewiki-uv-cache uv run python manage.py migrate
 UV_CACHE_DIR=/tmp/hivewiki-uv-cache uv run python manage.py test
 UV_CACHE_DIR=/tmp/hivewiki-uv-cache uv run python manage.py runserver
+```
+
+같은 작업을 devshell 안에서 실행하려면 아래처럼 사용할 수 있습니다.
+
+```bash
+nix develop --command python manage.py migrate
+nix develop --command python manage.py test
+nix develop --command python manage.py runserver
 ```
 
 이 프로젝트는 pre-commit hooks를 사용합니다.  
@@ -104,6 +115,8 @@ Commit message는 **영어로 작성해야 하며**, Conventional Commits 규칙
 - `DJANGO_SECURE_PROXY_SSL_HEADER`: 프록시 뒤에서 HTTPS 판별에 사용할 헤더
   예: `HTTP_X_FORWARDED_PROTO,https`
 - `SESSION_COOKIE_AGE`: 세션 유지 시간. 초 단위
+
+브라우저 timezone은 별도 엔드포인트 `POST /auth/timezone/`를 통해 세션 키 `django_timezone`에 저장됩니다. 이 값은 로그인/로그아웃 과정에서 세션이 재설정되어도 유지되며, 서버는 이를 사용해 사용자별 시간대를 활성화하고 클라이언트는 timezone-sensitive UI를 로컬 시간대로 다시 렌더링합니다.
 
 ### 로깅
 
@@ -150,6 +163,27 @@ OAuth callback URL은 현재 요청의 host/scheme를 기준으로 서버에서 
 - `POSTGRES_HOST`: PostgreSQL 호스트
 - `POSTGRES_PORT`: PostgreSQL 포트
 - `REDIS_URL`: Valkey/Redis URL. 세션 및 캐시에 사용
+
+## 운영 엔드포인트
+
+- `GET /livez/`: 프로세스 liveness 확인. 정상 시 `200 OK`
+- `GET /readyz/`: PostgreSQL과 Valkey readiness 확인. 하나라도 실패하면 `503 Service Unavailable`
+- `GET /metrics/`: Prometheus scrape endpoint
+
+`/metrics/`는 최소한 아래 메트릭을 제공합니다.
+
+- `hivewiki_up`
+- `hivewiki_process_start_time_seconds`
+- `hivewiki_build_info`
+- `hivewiki_readiness_check{check="database|cache"}`
+- `hivewiki_ready`
+- `hivewiki_http_requests_total{method,route}`
+- `hivewiki_http_responses_total{method,route,status_code}`
+- `hivewiki_http_request_duration_seconds_bucket{method,route,le}`
+- `hivewiki_http_request_duration_seconds_sum{method,route}`
+- `hivewiki_http_request_duration_seconds_count{method,route}`
+
+HTTP 메트릭의 `route` 라벨은 가능한 경우 raw path 대신 Django route pattern 기준으로 집계해 path parameter로 인한 cardinality 증가를 줄입니다.
 
 ## 배포 시 권장값
 

--- a/config/healthchecks.py
+++ b/config/healthchecks.py
@@ -1,0 +1,62 @@
+import ipaddress
+
+from django.conf import settings
+
+HEALTHCHECK_PATHS = frozenset(("/livez/", "/readyz/"))
+ELB_HEALTHCHECK_USER_AGENT_PREFIX = "ELB-HealthChecker/"
+
+
+class HealthcheckHostNormalizationMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        self._normalize_host_for_healthcheck(request)
+        return self.get_response(request)
+
+    def _normalize_host_for_healthcheck(self, request):
+        if request.path not in HEALTHCHECK_PATHS:
+            return
+
+        user_agent = request.META.get("HTTP_USER_AGENT", "")
+        if not user_agent.startswith(ELB_HEALTHCHECK_USER_AGENT_PREFIX):
+            return
+
+        host = request.META.get("HTTP_HOST", "")
+        if not _is_ip_host(host):
+            return
+
+        normalized_host = _first_canonical_allowed_host()
+        if normalized_host is None:
+            return
+
+        request.META["HTTP_HOST"] = normalized_host
+
+
+def _is_ip_host(host):
+    if not host:
+        return False
+
+    candidate = host
+    if candidate.startswith("[") and "]" in candidate:
+        candidate = candidate[1 : candidate.index("]")]
+    elif ":" in candidate and candidate.count(":") == 1:
+        candidate = candidate.split(":", 1)[0]
+
+    try:
+        ipaddress.ip_address(candidate)
+    except ValueError:
+        return False
+
+    return True
+
+
+def _first_canonical_allowed_host():
+    for host in settings.ALLOWED_HOSTS:
+        normalized_host = host.lstrip(".").strip()
+        if not normalized_host or normalized_host == "*":
+            continue
+        if _is_ip_host(normalized_host):
+            continue
+        return normalized_host
+    return None

--- a/config/logging.py
+++ b/config/logging.py
@@ -8,6 +8,8 @@ from datetime import UTC, datetime
 from asgiref.sync import iscoroutinefunction, markcoroutinefunction
 from django.conf import settings
 
+from config.observability import get_route_label, record_http_request
+
 _request_context: contextvars.ContextVar[dict[str, object] | None] = (
     contextvars.ContextVar(
         "request_context",
@@ -122,18 +124,31 @@ class RequestLoggingMiddleware:
         )
         return started_at, request_context_token, request_id
 
-    def _log_exception(self, started_at):
+    def _log_exception(self, request, started_at):
         duration_ms = round((time.perf_counter() - started_at) * 1000, 2)
         set_request_context(status_code=500, duration_ms=duration_ms)
+        record_http_request(
+            method=request.method,
+            route=get_route_label(request),
+            status_code=500,
+            duration_seconds=duration_ms / 1000,
+        )
         self.logger.exception("request_failed")
 
     def _log_response(self, request, response, started_at, request_id):
         duration_ms = round((time.perf_counter() - started_at) * 1000, 2)
+        duration_seconds = duration_ms / 1000
         user_id = _get_authenticated_user_id(request)
         set_request_context(
             status_code=response.status_code,
             duration_ms=duration_ms,
             user_id=user_id,
+        )
+        record_http_request(
+            method=request.method,
+            route=get_route_label(request),
+            status_code=response.status_code,
+            duration_seconds=duration_seconds,
         )
         self.logger.info("request_complete")
         response["X-Request-ID"] = request_id
@@ -148,7 +163,7 @@ class RequestLoggingMiddleware:
         try:
             response = self.get_response(request)
         except Exception:
-            self._log_exception(started_at)
+            self._log_exception(request, started_at)
             raise
         else:
             return self._log_response(
@@ -166,7 +181,7 @@ class RequestLoggingMiddleware:
         try:
             response = await self.get_response(request)
         except Exception:
-            self._log_exception(started_at)
+            self._log_exception(request, started_at)
             raise
         else:
             return self._log_response(

--- a/config/observability.py
+++ b/config/observability.py
@@ -1,0 +1,220 @@
+import platform
+import threading
+import time
+from importlib import metadata
+
+from django.core.cache import cache
+from django.db import connections
+from django.db.utils import DatabaseError
+from django.http import HttpResponse
+
+PROCESS_START_TIME = time.time()
+PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+REQUEST_DURATION_BUCKETS = (
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+)
+
+try:
+    APP_VERSION = metadata.version("hivewiki-web")
+except metadata.PackageNotFoundError:
+    APP_VERSION = "0.1.0"
+
+
+_metrics_lock = threading.Lock()
+_http_requests_total = {}
+_http_responses_total = {}
+_http_request_duration_seconds = {}
+
+
+def liveness_probe(_request):
+    return HttpResponse("ok\n", content_type="text/plain")
+
+
+def readiness_probe(_request):
+    checks = run_readiness_checks()
+    failed_checks = [name for name, ok in checks.items() if not ok]
+    if failed_checks:
+        body = "not ready: " + ", ".join(failed_checks) + "\n"
+        return HttpResponse(body, content_type="text/plain", status=503)
+
+    return HttpResponse("ready\n", content_type="text/plain")
+
+
+def metrics_view(_request):
+    checks = run_readiness_checks()
+    return HttpResponse(render_metrics(checks), content_type=PROMETHEUS_CONTENT_TYPE)
+
+
+def record_http_request(method, route, status_code, duration_seconds):
+    request_key = (method, route)
+    response_key = (method, route, str(status_code))
+
+    with _metrics_lock:
+        _http_requests_total[request_key] = _http_requests_total.get(request_key, 0) + 1
+        _http_responses_total[response_key] = (
+            _http_responses_total.get(response_key, 0) + 1
+        )
+
+        bucket_counts, total_sum, total_count = _http_request_duration_seconds.get(
+            request_key,
+            ({bucket: 0 for bucket in REQUEST_DURATION_BUCKETS}, 0.0, 0),
+        )
+        for bucket in REQUEST_DURATION_BUCKETS:
+            if duration_seconds <= bucket:
+                bucket_counts[bucket] += 1
+        _http_request_duration_seconds[request_key] = (
+            bucket_counts,
+            total_sum + duration_seconds,
+            total_count + 1,
+        )
+
+
+def reset_metrics():
+    with _metrics_lock:
+        _http_requests_total.clear()
+        _http_responses_total.clear()
+        _http_request_duration_seconds.clear()
+
+
+def run_readiness_checks():
+    return {
+        "database": check_database(),
+        "cache": check_cache(),
+    }
+
+
+def check_database():
+    try:
+        connection = connections["default"]
+        connection.ensure_connection()
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            cursor.fetchone()
+    except DatabaseError:
+        return False
+
+    return True
+
+
+def check_cache():
+    key = "hivewiki:healthcheck:ready"
+    value = str(time.time())
+
+    try:
+        cache.set(key, value, timeout=30)
+        cached_value = cache.get(key)
+        cache.delete(key)
+    except Exception:
+        return False
+
+    return cached_value == value
+
+
+def render_metrics(checks):
+    lines = [
+        "# HELP hivewiki_up Whether the Django process is running.",
+        "# TYPE hivewiki_up gauge",
+        "hivewiki_up 1",
+        "# HELP hivewiki_process_start_time_seconds Start time of the Django process since unix epoch in seconds.",
+        "# TYPE hivewiki_process_start_time_seconds gauge",
+        f"hivewiki_process_start_time_seconds {PROCESS_START_TIME:.6f}",
+        "# HELP hivewiki_build_info Static build and runtime information.",
+        "# TYPE hivewiki_build_info gauge",
+        (
+            f'hivewiki_build_info{{version="{APP_VERSION}",'
+            f'python_version="{platform.python_version()}"}} 1'
+        ),
+        "# HELP hivewiki_readiness_check Whether each readiness dependency is healthy.",
+        "# TYPE hivewiki_readiness_check gauge",
+    ]
+
+    for name, ok in checks.items():
+        lines.append(f'hivewiki_readiness_check{{check="{name}"}} {1 if ok else 0}')
+
+    overall_ready = 1 if all(checks.values()) else 0
+    lines.extend(
+        [
+            "# HELP hivewiki_ready Whether the application is ready to serve traffic.",
+            "# TYPE hivewiki_ready gauge",
+            f"hivewiki_ready {overall_ready}",
+            "# HELP hivewiki_http_requests_total Total number of HTTP requests received.",
+            "# TYPE hivewiki_http_requests_total counter",
+        ]
+    )
+
+    with _metrics_lock:
+        request_items = sorted(_http_requests_total.items())
+        response_items = sorted(_http_responses_total.items())
+        duration_items = sorted(_http_request_duration_seconds.items())
+
+    for (method, route), count in request_items:
+        labels = _format_labels(method=method, route=route)
+        lines.append(f"hivewiki_http_requests_total{labels} {count}")
+
+    lines.extend(
+        [
+            "# HELP hivewiki_http_responses_total Total number of HTTP responses sent.",
+            "# TYPE hivewiki_http_responses_total counter",
+        ]
+    )
+    for (method, route, status_code), count in response_items:
+        labels = _format_labels(method=method, route=route, status_code=status_code)
+        lines.append(f"hivewiki_http_responses_total{labels} {count}")
+
+    lines.extend(
+        [
+            "# HELP hivewiki_http_request_duration_seconds HTTP request latency in seconds.",
+            "# TYPE hivewiki_http_request_duration_seconds histogram",
+        ]
+    )
+    for (method, route), (bucket_counts, total_sum, total_count) in duration_items:
+        labels = _format_labels(method=method, route=route)
+        for bucket in REQUEST_DURATION_BUCKETS:
+            bucket_labels = _format_labels(method=method, route=route, le=str(bucket))
+            lines.append(
+                "hivewiki_http_request_duration_seconds_bucket"
+                f"{bucket_labels} {bucket_counts[bucket]}"
+            )
+        inf_labels = _format_labels(method=method, route=route, le="+Inf")
+        lines.append(
+            f"hivewiki_http_request_duration_seconds_bucket{inf_labels} {total_count}"
+        )
+        lines.append(
+            f"hivewiki_http_request_duration_seconds_sum{labels} {total_sum:.6f}"
+        )
+        lines.append(
+            f"hivewiki_http_request_duration_seconds_count{labels} {total_count}"
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def get_route_label(request):
+    resolver_match = getattr(request, "resolver_match", None)
+    if resolver_match and resolver_match.route:
+        route = f"/{resolver_match.route}"
+        return route if route.startswith("/") else f"/{route}"
+
+    path = request.path_info or "/"
+    return path if path.startswith("/") else f"/{path}"
+
+
+def _format_labels(**labels):
+    formatted = ",".join(
+        f'{key}="{_escape_label_value(value)}"' for key, value in labels.items()
+    )
+    return "{" + formatted + "}"
+
+
+def _escape_label_value(value):
+    return str(value).replace("\\", r"\\").replace('"', r"\"").replace("\n", r"\n")

--- a/config/observability.py
+++ b/config/observability.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import threading
 import time
@@ -7,9 +8,22 @@ from django.core.cache import cache
 from django.db import connections
 from django.db.utils import DatabaseError
 from django.http import HttpResponse
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    REGISTRY,
+    Counter,
+    Histogram,
+    generate_latest,
+)
+
+try:
+    from prometheus_client import CollectorRegistry, multiprocess
+except ImportError:  # pragma: no cover
+    CollectorRegistry = None
+    multiprocess = None
 
 PROCESS_START_TIME = time.time()
-PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+METRICS_READINESS_CACHE_TTL_SECONDS = 15
 REQUEST_DURATION_BUCKETS = (
     0.005,
     0.01,
@@ -23,6 +37,7 @@ REQUEST_DURATION_BUCKETS = (
     5.0,
     10.0,
 )
+EXCLUDED_REQUEST_METRIC_ROUTES = frozenset(("/livez/", "/readyz/", "/metrics/"))
 
 try:
     APP_VERSION = metadata.version("hivewiki-web")
@@ -31,9 +46,55 @@ except metadata.PackageNotFoundError:
 
 
 _metrics_lock = threading.Lock()
-_http_requests_total = {}
-_http_responses_total = {}
-_http_request_duration_seconds = {}
+_registered_collectors = []
+_http_requests_total = None
+_http_responses_total = None
+_http_request_duration_seconds = None
+
+_readiness_cache_lock = threading.Lock()
+_readiness_cache_checks = None
+_readiness_cache_expires_at = 0.0
+
+
+def _initialize_metrics():
+    global _http_request_duration_seconds
+    global _http_requests_total
+    global _http_responses_total
+
+    with _metrics_lock:
+        for collector in _registered_collectors:
+            try:
+                REGISTRY.unregister(collector)
+            except KeyError:
+                continue
+        _registered_collectors.clear()
+
+        _http_requests_total = Counter(
+            "hivewiki_http_requests_total",
+            "Total number of HTTP requests received.",
+            ("method", "route"),
+        )
+        _http_responses_total = Counter(
+            "hivewiki_http_responses_total",
+            "Total number of HTTP responses sent.",
+            ("method", "route", "status_code"),
+        )
+        _http_request_duration_seconds = Histogram(
+            "hivewiki_http_request_duration_seconds",
+            "HTTP request latency in seconds.",
+            ("method", "route"),
+            buckets=REQUEST_DURATION_BUCKETS,
+        )
+        _registered_collectors.extend(
+            [
+                _http_requests_total,
+                _http_responses_total,
+                _http_request_duration_seconds,
+            ]
+        )
+
+
+_initialize_metrics()
 
 
 def liveness_probe(_request):
@@ -51,39 +112,50 @@ def readiness_probe(_request):
 
 
 def metrics_view(_request):
-    checks = run_readiness_checks()
-    return HttpResponse(render_metrics(checks), content_type=PROMETHEUS_CONTENT_TYPE)
+    checks = get_cached_readiness_checks()
+    content = render_runtime_metrics(checks) + get_http_metrics_output()
+    return HttpResponse(content, content_type=CONTENT_TYPE_LATEST)
 
 
 def record_http_request(method, route, status_code, duration_seconds):
-    request_key = (method, route)
-    response_key = (method, route, str(status_code))
+    if route in EXCLUDED_REQUEST_METRIC_ROUTES:
+        return
 
-    with _metrics_lock:
-        _http_requests_total[request_key] = _http_requests_total.get(request_key, 0) + 1
-        _http_responses_total[response_key] = (
-            _http_responses_total.get(response_key, 0) + 1
-        )
-
-        bucket_counts, total_sum, total_count = _http_request_duration_seconds.get(
-            request_key,
-            ({bucket: 0 for bucket in REQUEST_DURATION_BUCKETS}, 0.0, 0),
-        )
-        for bucket in REQUEST_DURATION_BUCKETS:
-            if duration_seconds <= bucket:
-                bucket_counts[bucket] += 1
-        _http_request_duration_seconds[request_key] = (
-            bucket_counts,
-            total_sum + duration_seconds,
-            total_count + 1,
-        )
+    _http_requests_total.labels(method=method, route=route).inc()
+    _http_responses_total.labels(
+        method=method,
+        route=route,
+        status_code=str(status_code),
+    ).inc()
+    _http_request_duration_seconds.labels(method=method, route=route).observe(
+        duration_seconds
+    )
 
 
 def reset_metrics():
-    with _metrics_lock:
-        _http_requests_total.clear()
-        _http_responses_total.clear()
-        _http_request_duration_seconds.clear()
+    global _readiness_cache_checks
+    global _readiness_cache_expires_at
+
+    _initialize_metrics()
+    with _readiness_cache_lock:
+        _readiness_cache_checks = None
+        _readiness_cache_expires_at = 0.0
+
+
+def get_cached_readiness_checks():
+    global _readiness_cache_checks
+    global _readiness_cache_expires_at
+
+    now = time.monotonic()
+    with _readiness_cache_lock:
+        if _readiness_cache_checks is not None and now < _readiness_cache_expires_at:
+            return dict(_readiness_cache_checks)
+
+    checks = run_readiness_checks()
+    with _readiness_cache_lock:
+        _readiness_cache_checks = dict(checks)
+        _readiness_cache_expires_at = now + METRICS_READINESS_CACHE_TTL_SECONDS
+    return checks
 
 
 def run_readiness_checks():
@@ -120,7 +192,7 @@ def check_cache():
     return cached_value == value
 
 
-def render_metrics(checks):
+def render_runtime_metrics(checks):
     lines = [
         "# HELP hivewiki_up Whether the Django process is running.",
         "# TYPE hivewiki_up gauge",
@@ -147,56 +219,27 @@ def render_metrics(checks):
             "# HELP hivewiki_ready Whether the application is ready to serve traffic.",
             "# TYPE hivewiki_ready gauge",
             f"hivewiki_ready {overall_ready}",
-            "# HELP hivewiki_http_requests_total Total number of HTTP requests received.",
-            "# TYPE hivewiki_http_requests_total counter",
         ]
     )
-
-    with _metrics_lock:
-        request_items = sorted(_http_requests_total.items())
-        response_items = sorted(_http_responses_total.items())
-        duration_items = sorted(_http_request_duration_seconds.items())
-
-    for (method, route), count in request_items:
-        labels = _format_labels(method=method, route=route)
-        lines.append(f"hivewiki_http_requests_total{labels} {count}")
-
-    lines.extend(
-        [
-            "# HELP hivewiki_http_responses_total Total number of HTTP responses sent.",
-            "# TYPE hivewiki_http_responses_total counter",
-        ]
-    )
-    for (method, route, status_code), count in response_items:
-        labels = _format_labels(method=method, route=route, status_code=status_code)
-        lines.append(f"hivewiki_http_responses_total{labels} {count}")
-
-    lines.extend(
-        [
-            "# HELP hivewiki_http_request_duration_seconds HTTP request latency in seconds.",
-            "# TYPE hivewiki_http_request_duration_seconds histogram",
-        ]
-    )
-    for (method, route), (bucket_counts, total_sum, total_count) in duration_items:
-        labels = _format_labels(method=method, route=route)
-        for bucket in REQUEST_DURATION_BUCKETS:
-            bucket_labels = _format_labels(method=method, route=route, le=str(bucket))
-            lines.append(
-                "hivewiki_http_request_duration_seconds_bucket"
-                f"{bucket_labels} {bucket_counts[bucket]}"
-            )
-        inf_labels = _format_labels(method=method, route=route, le="+Inf")
-        lines.append(
-            f"hivewiki_http_request_duration_seconds_bucket{inf_labels} {total_count}"
-        )
-        lines.append(
-            f"hivewiki_http_request_duration_seconds_sum{labels} {total_sum:.6f}"
-        )
-        lines.append(
-            f"hivewiki_http_request_duration_seconds_count{labels} {total_count}"
-        )
-
     return "\n".join(lines) + "\n"
+
+
+def get_http_metrics_output():
+    registry = get_metrics_registry()
+    return generate_latest(registry).decode("utf-8")
+
+
+def get_metrics_registry():
+    if multiprocess is None or CollectorRegistry is None:
+        return REGISTRY
+
+    multiproc_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR", "").strip()
+    if not multiproc_dir:
+        return REGISTRY
+
+    registry = CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry)
+    return registry
 
 
 def get_route_label(request):
@@ -207,14 +250,3 @@ def get_route_label(request):
 
     path = request.path_info or "/"
     return path if path.startswith("/") else f"/{path}"
-
-
-def _format_labels(**labels):
-    formatted = ",".join(
-        f'{key}="{_escape_label_value(value)}"' for key, value in labels.items()
-    )
-    return "{" + formatted + "}"
-
-
-def _escape_label_value(value):
-    return str(value).replace("\\", r"\\").replace('"', r"\"").replace("\n", r"\n")

--- a/config/settings.py
+++ b/config/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "config.healthchecks.HealthcheckHostNormalizationMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/config/tests/test_healthchecks.py
+++ b/config/tests/test_healthchecks.py
@@ -1,0 +1,47 @@
+from django.http import HttpResponse
+from django.test import SimpleTestCase, override_settings
+from django.urls import path
+
+
+def ok_view(_request):
+    return HttpResponse("ok", content_type="text/plain")
+
+
+urlpatterns = [
+    path("livez/", ok_view),
+    path("dashboard/", ok_view),
+]
+
+
+@override_settings(
+    ROOT_URLCONF="config.tests.test_healthchecks",
+    ALLOWED_HOSTS=["test.hive-wiki.com"],
+)
+class HealthcheckHostNormalizationMiddlewareTests(SimpleTestCase):
+    def test_elb_healthcheck_ip_host_is_normalized_for_livez(self):
+        response = self.client.get(
+            "/livez/",
+            HTTP_HOST="10.0.0.42",
+            HTTP_USER_AGENT="ELB-HealthChecker/2.0",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), "ok")
+
+    def test_non_healthcheck_path_still_rejects_ip_host(self):
+        response = self.client.get(
+            "/dashboard/",
+            HTTP_HOST="10.0.0.42",
+            HTTP_USER_AGENT="ELB-HealthChecker/2.0",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_non_elb_user_agent_still_rejects_ip_host_for_livez(self):
+        response = self.client.get(
+            "/livez/",
+            HTTP_HOST="10.0.0.42",
+            HTTP_USER_AGENT="curl/8.0.1",
+        )
+
+        self.assertEqual(response.status_code, 400)

--- a/config/tests/test_observability.py
+++ b/config/tests/test_observability.py
@@ -1,0 +1,77 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from config.observability import reset_metrics
+
+
+class ObservabilityViewsTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        reset_metrics()
+
+    def test_liveness_probe_returns_ok(self):
+        response = self.client.get("/livez/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response["Content-Type"].startswith("text/plain"))
+        self.assertEqual(response.content.decode(), "ok\n")
+
+    @patch("config.observability.run_readiness_checks")
+    def test_readiness_probe_returns_ready_when_all_checks_pass(
+        self, run_readiness_checks
+    ):
+        run_readiness_checks.return_value = {"database": True, "cache": True}
+
+        response = self.client.get("/readyz/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), "ready\n")
+
+    @patch("config.observability.run_readiness_checks")
+    def test_readiness_probe_returns_503_with_failed_checks(self, run_readiness_checks):
+        run_readiness_checks.return_value = {"database": False, "cache": True}
+
+        response = self.client.get("/readyz/")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.content.decode(), "not ready: database\n")
+
+    @patch("config.observability.run_readiness_checks")
+    def test_metrics_view_renders_prometheus_text_format(self, run_readiness_checks):
+        run_readiness_checks.return_value = {"database": True, "cache": False}
+
+        response = self.client.get("/metrics/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response["Content-Type"],
+            "text/plain; version=0.0.4; charset=utf-8",
+        )
+        content = response.content.decode()
+        self.assertIn(
+            "# HELP hivewiki_up Whether the Django process is running.", content
+        )
+        self.assertIn('hivewiki_readiness_check{check="database"} 1', content)
+        self.assertIn('hivewiki_readiness_check{check="cache"} 0', content)
+        self.assertIn("hivewiki_ready 0", content)
+
+    @patch("config.observability.run_readiness_checks")
+    def test_metrics_view_includes_http_request_metrics(self, run_readiness_checks):
+        run_readiness_checks.return_value = {"database": True, "cache": True}
+
+        self.client.get("/livez/")
+        response = self.client.get("/metrics/")
+
+        content = response.content.decode()
+        self.assertIn(
+            'hivewiki_http_requests_total{method="GET",route="/livez/"} 1', content
+        )
+        self.assertIn(
+            'hivewiki_http_responses_total{method="GET",route="/livez/",status_code="200"} 1',
+            content,
+        )
+        self.assertIn(
+            'hivewiki_http_request_duration_seconds_count{method="GET",route="/livez/"} 1',
+            content,
+        )

--- a/config/tests/test_observability.py
+++ b/config/tests/test_observability.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
-from config.observability import reset_metrics
+from config.observability import record_http_request, reset_metrics
 
 
 class ObservabilityViewsTests(SimpleTestCase):
@@ -44,10 +44,7 @@ class ObservabilityViewsTests(SimpleTestCase):
         response = self.client.get("/metrics/")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response["Content-Type"],
-            "text/plain; version=0.0.4; charset=utf-8",
-        )
+        self.assertTrue(response["Content-Type"].startswith("text/plain"))
         content = response.content.decode()
         self.assertIn(
             "# HELP hivewiki_up Whether the Django process is running.", content
@@ -60,18 +57,32 @@ class ObservabilityViewsTests(SimpleTestCase):
     def test_metrics_view_includes_http_request_metrics(self, run_readiness_checks):
         run_readiness_checks.return_value = {"database": True, "cache": True}
 
-        self.client.get("/livez/")
+        record_http_request("GET", "/dashboard/", 200, 0.1)
         response = self.client.get("/metrics/")
 
         content = response.content.decode()
         self.assertIn(
-            'hivewiki_http_requests_total{method="GET",route="/livez/"} 1', content
-        )
-        self.assertIn(
-            'hivewiki_http_responses_total{method="GET",route="/livez/",status_code="200"} 1',
+            'hivewiki_http_requests_total{method="GET",route="/dashboard/"} 1.0',
             content,
         )
         self.assertIn(
-            'hivewiki_http_request_duration_seconds_count{method="GET",route="/livez/"} 1',
+            'hivewiki_http_responses_total{method="GET",route="/dashboard/",status_code="200"} 1.0',
             content,
         )
+        self.assertIn(
+            'hivewiki_http_request_duration_seconds_count{method="GET",route="/dashboard/"} 1.0',
+            content,
+        )
+        self.assertNotIn('route="/metrics/"', content)
+        self.assertNotIn('route="/readyz/"', content)
+
+    @patch("config.observability.run_readiness_checks")
+    def test_metrics_view_caches_readiness_checks_between_scrapes(
+        self, run_readiness_checks
+    ):
+        run_readiness_checks.return_value = {"database": True, "cache": True}
+
+        self.client.get("/metrics/")
+        self.client.get("/metrics/")
+
+        self.assertEqual(run_readiness_checks.call_count, 1)

--- a/config/urls.py
+++ b/config/urls.py
@@ -18,8 +18,13 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 
+from config.observability import liveness_probe, metrics_view, readiness_probe
+
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("livez/", liveness_probe),
+    path("readyz/", readiness_probe),
+    path("metrics/", metrics_view),
     path("", include("apps.accounts.urls")),
     path("", include("apps.core.urls")),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "django-redis>=6.0.0",
     "django-tailwind>=4.4.2",
     "psycopg[binary]>=3.3.3",
+    "prometheus-client>=0.23.1,<1.0",
     "uvicorn>=0.42.0",
     "whitenoise>=6.12.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -154,6 +154,7 @@ dependencies = [
     { name = "django-redis" },
     { name = "django-tailwind" },
     { name = "markdown" },
+    { name = "prometheus-client" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pygments" },
     { name = "pymdown-extensions" },
@@ -176,6 +177,7 @@ requires-dist = [
     { name = "django-redis", specifier = ">=6.0.0" },
     { name = "django-tailwind", specifier = ">=4.4.2" },
     { name = "markdown", specifier = ">=3.9,<4.0" },
+    { name = "prometheus-client", specifier = ">=0.23.1,<1.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
     { name = "pygments", specifier = ">=2.19.0,<3.0" },
     { name = "pymdown-extensions", specifier = ">=10.16.0,<11.0" },
@@ -237,6 +239,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add liveness and readiness probe endpoints for process, database, and cache health
- expose Prometheus metrics including request count, response status count, and request latency histograms
- update README with observability endpoints, metrics, timezone behavior, and current local run guidance

## Testing
- python manage.py test config.tests.test_observability config.tests.test_request_logging
- pre-commit run --all-files