### PR TITLE
Fixinsert dummy on building image to collect static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,15 @@ RUN uv sync --frozen --no-dev --no-install-project
 
 COPY . .
 RUN uv sync --frozen --no-dev --no-install-project
-RUN uv run python manage.py collectstatic --noinput
+RUN DJANGO_SECRET_KEY=build-only-secret \
+    POSTGRES_DB=build \
+    POSTGRES_USER=build \
+    POSTGRES_PASSWORD=build \
+    POSTGRES_HOST=127.0.0.1 \
+    POSTGRES_PORT=5432 \
+    REDIS_URL=redis://127.0.0.1:6379/0 \
+    uv run python manage.py collectstatic --noinput
+
 
 USER app
 


### PR DESCRIPTION
js를 포함시키기 위해 collectstatic을 dockerfile에 추가하면서 생긴 빌드 오류 수정

dummy데이터를 넣어 해결
