### PR TITLE
fix: 헬스체크 엔드포인트에 대해 로깅하지 않도록 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Commit message는 **영어로 작성해야 하며**, Conventional Commits 규칙
 - `DJANGO_X_FRAME_OPTIONS`: `X-Frame-Options` 값. 기본 `DENY`
 - `DJANGO_LOG_LEVEL`: 애플리케이션 로그 레벨. 기본 `INFO`
 - `DJANGO_LOG_JSON`: JSON 구조화 로그 사용 여부. 기본 `True`
+- `DJANGO_LOG_HEALTHCHECKS`: `/livez/`, `/readyz/` access 로그 출력 여부. 기본 `False`
 - `DJANGO_SECURE_PROXY_SSL_HEADER`: 프록시 뒤에서 HTTPS 판별에 사용할 헤더
   예: `HTTP_X_FORWARDED_PROTO,https`
 - `SESSION_COOKIE_AGE`: 세션 유지 시간. 초 단위

--- a/config/logging.py
+++ b/config/logging.py
@@ -1,7 +1,6 @@
 import contextvars
 import json
 import logging
-import re
 import time
 import uuid
 from datetime import UTC, datetime
@@ -19,10 +18,7 @@ _request_context: contextvars.ContextVar[dict[str, object] | None] = (
     )
 )
 HEALTHCHECK_PATHS = frozenset(("/livez/", "/readyz/"))
-ACCESS_LOGGER_NAMES = frozenset(
-    ("django.server", "gunicorn.access", "hivewiki.request", "uvicorn.access")
-)
-REQUEST_LINE_PATH_PATTERN = re.compile(r'"[A-Z]+ (?P<path>\S+) HTTP/[\d.]+"')
+ACCESS_LOGGER_NAMES = frozenset(("django.server", "hivewiki.request", "uvicorn.access"))
 
 
 def _utc_timestamp() -> str:
@@ -99,7 +95,7 @@ class SuppressHealthcheckAccessLogsFilter(logging.Filter):
         if record.name == "django.server":
             return self._get_django_server_path(record)
 
-        return self._get_path_from_message(record)
+        return None
 
     def _get_uvicorn_access_path(self, record: logging.LogRecord) -> str | None:
         args = getattr(record, "args", ())
@@ -110,19 +106,13 @@ class SuppressHealthcheckAccessLogsFilter(logging.Filter):
     def _get_django_server_path(self, record: logging.LogRecord) -> str | None:
         args = getattr(record, "args", ())
         if not args:
-            return self._get_path_from_message(record)
+            return None
 
         request_line = str(args[0])
         parts = request_line.split()
         if len(parts) < 2:
-            return self._get_path_from_message(record)
-        return parts[1]
-
-    def _get_path_from_message(self, record: logging.LogRecord) -> str | None:
-        match = REQUEST_LINE_PATH_PATTERN.search(record.getMessage())
-        if match is None:
             return None
-        return match.group("path")
+        return parts[1]
 
 
 class JsonFormatter(logging.Formatter):

--- a/config/logging.py
+++ b/config/logging.py
@@ -1,9 +1,11 @@
 import contextvars
 import json
 import logging
+import re
 import time
 import uuid
 from datetime import UTC, datetime
+from urllib.parse import urlsplit
 
 from asgiref.sync import iscoroutinefunction, markcoroutinefunction
 from django.conf import settings
@@ -16,6 +18,11 @@ _request_context: contextvars.ContextVar[dict[str, object] | None] = (
         default=None,
     )
 )
+HEALTHCHECK_PATHS = frozenset(("/livez/", "/readyz/"))
+ACCESS_LOGGER_NAMES = frozenset(
+    ("django.server", "gunicorn.access", "hivewiki.request", "uvicorn.access")
+)
+REQUEST_LINE_PATH_PATTERN = re.compile(r'"[A-Z]+ (?P<path>\S+) HTTP/[\d.]+"')
 
 
 def _utc_timestamp() -> str:
@@ -30,6 +37,21 @@ def set_request_context(**kwargs) -> None:
     context = dict(_request_context.get() or {})
     context.update({key: value for key, value in kwargs.items() if value is not None})
     _request_context.set(context)
+
+
+def _normalize_path(path: str | None) -> str:
+    normalized_path = urlsplit(path or "").path or "/"
+    if normalized_path != "/" and not normalized_path.endswith("/"):
+        normalized_path = f"{normalized_path}/"
+    return normalized_path
+
+
+def is_healthcheck_path(path: str | None) -> bool:
+    return _normalize_path(path) in HEALTHCHECK_PATHS
+
+
+def should_log_healthcheck_requests() -> bool:
+    return getattr(settings, "DJANGO_LOG_HEALTHCHECKS", False)
 
 
 class RequestContextFilter(logging.Filter):
@@ -47,6 +69,60 @@ class RequestContextFilter(logging.Filter):
         ):
             setattr(record, field, context.get(field))
         return True
+
+
+class SuppressHealthcheckAccessLogsFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        if should_log_healthcheck_requests():
+            return True
+
+        if record.name not in ACCESS_LOGGER_NAMES:
+            return True
+
+        path = self._get_path(record)
+        if not is_healthcheck_path(path):
+            return True
+
+        if record.name == "hivewiki.request":
+            return record.getMessage() != "request_complete"
+
+        return False
+
+    def _get_path(self, record: logging.LogRecord) -> str | None:
+        path = getattr(record, "path", None)
+        if path:
+            return path
+
+        if record.name == "uvicorn.access":
+            return self._get_uvicorn_access_path(record)
+
+        if record.name == "django.server":
+            return self._get_django_server_path(record)
+
+        return self._get_path_from_message(record)
+
+    def _get_uvicorn_access_path(self, record: logging.LogRecord) -> str | None:
+        args = getattr(record, "args", ())
+        if len(args) < 3:
+            return None
+        return str(args[2])
+
+    def _get_django_server_path(self, record: logging.LogRecord) -> str | None:
+        args = getattr(record, "args", ())
+        if not args:
+            return self._get_path_from_message(record)
+
+        request_line = str(args[0])
+        parts = request_line.split()
+        if len(parts) < 2:
+            return self._get_path_from_message(record)
+        return parts[1]
+
+    def _get_path_from_message(self, record: logging.LogRecord) -> str | None:
+        match = REQUEST_LINE_PATH_PATTERN.search(record.getMessage())
+        if match is None:
+            return None
+        return match.group("path")
 
 
 class JsonFormatter(logging.Formatter):
@@ -150,7 +226,10 @@ class RequestLoggingMiddleware:
             status_code=response.status_code,
             duration_seconds=duration_seconds,
         )
-        self.logger.info("request_complete")
+        if should_log_healthcheck_requests() or not is_healthcheck_path(
+            request.path_info
+        ):
+            self.logger.info("request_complete")
         response["X-Request-ID"] = request_id
         return response
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -6,6 +6,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 env = environ.Env(
     DJANGO_DEBUG=(bool, True),
     DJANGO_LOG_JSON=(bool, True),
+    DJANGO_LOG_HEALTHCHECKS=(bool, False),
     DJANGO_SESSION_COOKIE_SECURE=(bool, False),
     DJANGO_CSRF_COOKIE_SECURE=(bool, False),
     DJANGO_SECURE_SSL_REDIRECT=(bool, False),
@@ -23,6 +24,7 @@ environ.Env.read_env(BASE_DIR / ".env")
 SECRET_KEY = env("DJANGO_SECRET_KEY")
 DEBUG = env("DJANGO_DEBUG")
 DJANGO_LOG_JSON = env("DJANGO_LOG_JSON")
+DJANGO_LOG_HEALTHCHECKS = env("DJANGO_LOG_HEALTHCHECKS")
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=[])
 CSRF_TRUSTED_ORIGINS = env.list("DJANGO_CSRF_TRUSTED_ORIGINS", default=[])
 CLIENT_IP_HEADER = env("DJANGO_CLIENT_IP_HEADER", default="")
@@ -190,6 +192,9 @@ LOGGING = {
         "request_context": {
             "()": "config.logging.RequestContextFilter",
         },
+        "suppress_healthcheck_access_logs": {
+            "()": "config.logging.SuppressHealthcheckAccessLogsFilter",
+        },
     },
     "formatters": {
         "json": {
@@ -202,7 +207,7 @@ LOGGING = {
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
-            "filters": ["request_context"],
+            "filters": ["request_context", "suppress_healthcheck_access_logs"],
             "formatter": "json" if DJANGO_LOG_JSON else "plain",
         },
     },
@@ -224,6 +229,16 @@ LOGGING = {
         "hivewiki.request": {
             "handlers": ["console"],
             "level": "INFO",
+            "propagate": False,
+        },
+        "uvicorn.access": {
+            "handlers": ["console"],
+            "level": DJANGO_LOG_LEVEL,
+            "propagate": False,
+        },
+        "gunicorn.access": {
+            "handlers": ["console"],
+            "level": DJANGO_LOG_LEVEL,
             "propagate": False,
         },
     },

--- a/config/tests/test_logging_filters.py
+++ b/config/tests/test_logging_filters.py
@@ -1,0 +1,92 @@
+import logging
+
+from django.test import SimpleTestCase, override_settings
+
+from config.logging import SuppressHealthcheckAccessLogsFilter
+
+
+class SuppressHealthcheckAccessLogsFilterTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.filter = SuppressHealthcheckAccessLogsFilter()
+
+    def test_suppresses_hivewiki_request_completion_for_healthcheck(self):
+        record = logging.LogRecord(
+            name="hivewiki.request",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="request_complete",
+            args=(),
+            exc_info=None,
+        )
+        record.path = "/livez/"
+
+        self.assertFalse(self.filter.filter(record))
+
+    def test_keeps_hivewiki_request_failures_for_healthcheck(self):
+        record = logging.LogRecord(
+            name="hivewiki.request",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg="request_failed",
+            args=(),
+            exc_info=None,
+        )
+        record.path = "/readyz/"
+
+        self.assertTrue(self.filter.filter(record))
+
+    def test_suppresses_uvicorn_access_log_for_healthcheck(self):
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg='%s - "%s %s HTTP/%s" %d',
+            args=("127.0.0.1:54321", "GET", "/readyz/", "1.1", 200),
+            exc_info=None,
+        )
+
+        self.assertFalse(self.filter.filter(record))
+
+    def test_suppresses_django_server_access_log_for_healthcheck(self):
+        record = logging.LogRecord(
+            name="django.server",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg='"%s" %s %s',
+            args=("GET /livez/ HTTP/1.1", 200, 3),
+            exc_info=None,
+        )
+
+        self.assertFalse(self.filter.filter(record))
+
+    def test_keeps_uvicorn_access_log_for_non_healthcheck(self):
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg='%s - "%s %s HTTP/%s" %d',
+            args=("127.0.0.1:54321", "GET", "/dashboard/", "1.1", 200),
+            exc_info=None,
+        )
+
+        self.assertTrue(self.filter.filter(record))
+
+    @override_settings(DJANGO_LOG_HEALTHCHECKS=True)
+    def test_can_enable_healthcheck_access_logs(self):
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg='%s - "%s %s HTTP/%s" %d',
+            args=("127.0.0.1:54321", "GET", "/livez/", "1.1", 200),
+            exc_info=None,
+        )
+
+        self.assertTrue(self.filter.filter(record))

--- a/config/tests/test_request_logging.py
+++ b/config/tests/test_request_logging.py
@@ -1,7 +1,12 @@
+from unittest.mock import patch
+
 from asgiref.sync import async_to_sync
 from django.http import HttpResponse, StreamingHttpResponse
 from django.test import AsyncClient, SimpleTestCase, override_settings
 from django.urls import path
+
+from config.logging import RequestLoggingMiddleware
+from config.observability import liveness_probe
 
 
 async def async_request_id_view(request):
@@ -15,6 +20,7 @@ def streaming_request_id_view(request):
 urlpatterns = [
     path("async-request-id/", async_request_id_view),
     path("streaming-request-id/", streaming_request_id_view),
+    path("livez/", liveness_probe),
 ]
 
 
@@ -35,3 +41,19 @@ class RequestLoggingMiddlewareTests(SimpleTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(b"".join(response.streaming_content).decode(), request_id)
+
+    def test_healthcheck_path_skips_request_complete_log_by_default(self):
+        with patch.object(RequestLoggingMiddleware.logger, "info") as logger_info:
+            response = self.client.get("/livez/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("X-Request-ID", response.headers)
+        logger_info.assert_not_called()
+
+    @override_settings(DJANGO_LOG_HEALTHCHECKS=True)
+    def test_healthcheck_path_logs_when_enabled(self):
+        with patch.object(RequestLoggingMiddleware.logger, "info") as logger_info:
+            response = self.client.get("/livez/")
+
+        self.assertEqual(response.status_code, 200)
+        logger_info.assert_called_once_with("request_complete")


### PR DESCRIPTION
헬스체크 엔드포인트에 대한 로깅이 너무 많이 쌓이는 것을 인지하고, 헬스체크 엔드포인트에 대해 로깅하는 것을 토글가능하도록 수정. 기본 False.