### PR TITLE
fix(layout): improve public footer spacing

### DIFF
--- a/templates/layouts/public.html
+++ b/templates/layouts/public.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block body %}
-    <div class="relative min-h-screen overflow-hidden bg-surface">
+    <div class="relative flex min-h-screen flex-col overflow-hidden bg-surface">
         <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(255,193,7,0.22),_transparent_34%),radial-gradient(circle_at_bottom_right,_rgba(0,104,119,0.12),_transparent_28%)]">
         </div>
         <header class="glass-nav sticky top-0 z-40 border-b border-white/50">
@@ -36,7 +36,7 @@
                 </nav>
             </div>
         </header>
-        <main class="relative">
+        <main class="relative flex-1">
             {% block content %}
             {% endblock content %}
         </main>

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -1,5 +1,5 @@
 <footer class="border-t border-stone-200/70 bg-surface-container-low">
-    <div class="mx-auto flex max-w-7xl flex-col gap-4 px-6 py-6 text-sm text-on-surface-variant lg:flex-row lg:items-center lg:justify-between lg:px-10">
+    <div class="mx-auto flex max-w-7xl flex-col gap-4 px-6 py-6 text-sm text-on-surface-variant lg:flex-row lg:items-center lg:justify-between lg:px-10 lg:py-8">
         <div class="flex items-center gap-3">
             <span class="flex h-8 w-8 items-center justify-center rounded-full bg-stone-950 text-xs font-black text-white">W</span>
             <span class="font-semibold text-on-surface">Workerbees</span>


### PR DESCRIPTION
## Summary
- make the public layout use a flex column so the footer stays pinned to the bottom on tall screens
- let the public main content grow to fill the viewport height
- add a bit more large-screen vertical padding to the footer

## Testing
- pre-commit hooks run during commit
