### PR TITLE
feat: improve integrated search results

### DIFF
--- a/apps/core/search.py
+++ b/apps/core/search.py
@@ -1,9 +1,9 @@
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
 from django.db import connection
-from django.db.models import Q
+from django.db.models import Count, Q
 from django.urls import reverse
 
-from .models import WikiDocument, WikiDocumentStatus
+from .models import Post, PostStatus, WikiDocument, WikiDocumentStatus
 
 
 def get_wiki_search_results(*, query="", limit=12):
@@ -60,4 +60,60 @@ def get_wiki_search_results(*, query="", limit=12):
             }
             for document in documents
         ],
+    }
+
+
+def get_post_search_results(*, query="", limit=12):
+    posts = (
+        Post.objects.filter(status=PostStatus.PUBLISHED, deleted_at__isnull=True)
+        .select_related("author_user")
+        .prefetch_related("tags", "wiki_documents")
+        .annotate(
+            comment_count=Count(
+                "comments",
+                filter=Q(comments__deleted_at__isnull=True),
+                distinct=True,
+            ),
+            like_count=Count("post_likes__user", distinct=True),
+        )
+        .order_by("-created_at", "-id")
+    )
+    normalized_query = query.strip()
+    if normalized_query:
+        if connection.vendor == "postgresql":
+            search_vector = (
+                SearchVector("title_cache", weight="A", config="simple")
+                + SearchVector("summary_cache", weight="B", config="simple")
+                + SearchVector("body_markdown_cache", weight="C", config="simple")
+            )
+            search_query = SearchQuery(
+                normalized_query,
+                config="simple",
+                search_type="websearch",
+            )
+            posts = posts.annotate(
+                search_vector=search_vector,
+                search_rank=SearchRank(search_vector, search_query),
+            ).filter(
+                Q(search_vector=search_query)
+                | Q(tags__name__icontains=normalized_query)
+                | Q(wiki_documents__title__icontains=normalized_query)
+            )
+            posts = posts.distinct().order_by(
+                "-search_rank", "-comment_count", "-created_at", "-id"
+            )
+        else:
+            posts = posts.filter(
+                Q(title_cache__icontains=normalized_query)
+                | Q(summary_cache__icontains=normalized_query)
+                | Q(body_markdown_cache__icontains=normalized_query)
+                | Q(tags__name__icontains=normalized_query)
+                | Q(wiki_documents__title__icontains=normalized_query)
+            ).distinct()
+
+    total_count = posts.count()
+    return {
+        "query": normalized_query,
+        "total_count": total_count,
+        "items": list(posts[:limit]),
     }

--- a/apps/core/tests/test_community_views.py
+++ b/apps/core/tests/test_community_views.py
@@ -15,6 +15,10 @@ from apps.core.models import (
     PostStatus,
     Tag,
     TagType,
+    WikiDocument,
+    WikiDocumentStatus,
+    WikiGenerationType,
+    WikiRevision,
 )
 from apps.core.views import _community_visible_posts_queryset
 
@@ -26,6 +30,14 @@ from apps.core.views import _community_visible_posts_queryset
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "hivewiki-community-test-cache",
         }
+    },
+    STORAGES={
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
     },
 )
 class CommunityViewTests(TestCase):
@@ -216,6 +228,61 @@ class CommunityViewTests(TestCase):
         )
         comment.refresh_from_db()
         self.assertEqual(comment.content, "수정된 댓글")
+
+    def test_community_detail_prioritizes_related_posts_over_hot_posts(self):
+        tag = Tag.objects.create(name="검색", slug="search", tag_type=TagType.USER)
+        shared_document = WikiDocument.objects.create(
+            title="검색 구조 문서",
+            slug="search-structure-doc",
+            summary="검색 구조를 정리한 문서입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        shared_revision = WikiRevision.objects.create(
+            wiki_document=shared_document,
+            revision_number=1,
+            content_markdown="## 검색 구조",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        shared_document.current_revision = shared_revision
+        shared_document.save(update_fields=["current_revision"])
+
+        current_post = Post.objects.create(
+            author_user=self.user,
+            content_markdown="# 검색 개선 논의\n\n검색 결과 구조를 다듬습니다.",
+            status=PostStatus.PUBLISHED,
+        )
+        current_post.tags.add(tag)
+        current_post.wiki_documents.add(shared_document)
+
+        related_post = Post.objects.create(
+            author_user=self.other_user,
+            content_markdown="# 검색 UX 제안\n\n검색 구조와 필터 동선을 정리합니다.",
+            status=PostStatus.PUBLISHED,
+        )
+        related_post.tags.add(tag)
+        related_post.wiki_documents.add(shared_document)
+
+        hot_but_unrelated_post = Post.objects.create(
+            author_user=self.other_user,
+            content_markdown="# 자유 주제 토론\n\n검색과 무관한 인기 글입니다.",
+            status=PostStatus.PUBLISHED,
+        )
+        for index in range(3):
+            Comment.objects.create(
+                post=hot_but_unrelated_post,
+                author_user=self.user,
+                content=f"인기 댓글 {index}",
+            )
+
+        response = self.client.get(f"/community/{current_post.id}/")
+
+        self.assertEqual(response.status_code, 200)
+        related_posts = response.context["related_posts"]
+        self.assertGreaterEqual(len(related_posts), 2)
+        self.assertEqual(related_posts[0].pk, related_post.pk)
+        self.assertContains(response, "연관 게시글")
 
     @patch("apps.core.views.notify_post_liked")
     def test_post_like_creates_notification_on_new_like(self, mock_notify_post_liked):

--- a/apps/core/tests/test_search_views.py
+++ b/apps/core/tests/test_search_views.py
@@ -2,7 +2,12 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
+from apps.accounts.models import HiveUser, UserStatus
 from apps.core.models import (
+    Post,
+    PostStatus,
+    Tag,
+    TagType,
     WikiDocument,
     WikiDocumentStatus,
     WikiGenerationType,
@@ -18,9 +23,17 @@ from apps.core.models import (
             "LOCATION": "hivewiki-search-test-cache",
         }
     },
+    STORAGES={
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    },
 )
 class SearchViewTests(TestCase):
-    def test_integrated_search_only_shows_matching_wiki_documents(self):
+    def test_integrated_search_shows_matching_wiki_documents_and_posts(self):
         matching_document = WikiDocument.objects.create(
             title="커뮤니티 질문을 위키로 전환하는 기준",
             slug="community-to-wiki-criteria",
@@ -55,13 +68,32 @@ class SearchViewTests(TestCase):
         non_matching_document.current_revision = non_matching_revision
         non_matching_document.save(update_fields=["current_revision"])
 
+        author = HiveUser.objects.create(
+            username="search_author",
+            email="search-author@example.com",
+            status=UserStatus.ACTIVE,
+        )
+        Post.objects.create(
+            author_user=author,
+            content_markdown="# 선정 기준 논의\n\n반복 질문을 문서화하는 기준을 정리합니다.",
+            status=PostStatus.PUBLISHED,
+        )
+        Post.objects.create(
+            author_user=author,
+            content_markdown="# 운영 회고\n\n주간 운영 이슈를 정리합니다.",
+            status=PostStatus.PUBLISHED,
+        )
+
         response = self.client.get("/search/", {"q": "선정 기준"})
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "문서 검색")
+        self.assertContains(response, "통합 검색")
         self.assertContains(response, "커뮤니티 질문을 위키로 전환하는 기준")
+        self.assertContains(response, "반복 질문을 문서화하는 기준을 정리합니다.")
         self.assertNotContains(response, "캡스톤 위키 운영 가이드")
-        self.assertNotContains(response, "게시글 결과")
+        self.assertNotContains(response, "운영 회고")
+        self.assertContains(response, "게시글")
+        self.assertContains(response, "문서 1건 · 게시글 1건")
 
     def test_integrated_search_shows_total_count_before_limit(self):
         for index in range(18):
@@ -89,6 +121,48 @@ class SearchViewTests(TestCase):
         self.assertContains(response, "18건")
         self.assertContains(response, "운영 기준 문서 17")
         self.assertNotContains(response, "운영 기준 문서 0")
+
+    def test_integrated_search_matches_post_tags_and_linked_wiki_titles(self):
+        author = HiveUser.objects.create(
+            username="post_author",
+            email="post-search@example.com",
+            status=UserStatus.ACTIVE,
+        )
+        linked_document = WikiDocument.objects.create(
+            title="캡스톤 발표 준비",
+            slug="capstone-demo-prep",
+            summary="발표 준비 문서입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        linked_revision = WikiRevision.objects.create(
+            wiki_document=linked_document,
+            revision_number=1,
+            content_markdown="## 발표 체크리스트",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        linked_document.current_revision = linked_revision
+        linked_document.save(update_fields=["current_revision"])
+        tag = Tag.objects.create(
+            name="발표", slug="presentation", tag_type=TagType.USER
+        )
+
+        matching_post = Post.objects.create(
+            author_user=author,
+            content_markdown="# 데모 일정 공유\n\n이번 주 준비 상황을 정리합니다.",
+            status=PostStatus.PUBLISHED,
+        )
+        matching_post.tags.add(tag)
+        matching_post.wiki_documents.add(linked_document)
+
+        response = self.client.get("/search/", {"q": "발표"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "이번 주 준비 상황을 정리합니다.")
+        self.assertContains(response, "#발표")
+        self.assertContains(response, "캡스톤 발표 준비")
+        self.assertContains(response, "게시글 1건")
 
     def test_wiki_home_filters_documents_for_htmx_requests(self):
         matching_document = WikiDocument.objects.create(
@@ -173,6 +247,17 @@ class SearchViewTests(TestCase):
         document.current_revision = revision
         document.save(update_fields=["current_revision"])
 
+        author = HiveUser.objects.create(
+            username="recent_author",
+            email="recent-post@example.com",
+            status=UserStatus.ACTIVE,
+        )
+        Post.objects.create(
+            author_user=author,
+            content_markdown="# 최근 커뮤니티 글\n\n최근 공개된 게시글입니다.",
+            status=PostStatus.PUBLISHED,
+        )
+
         response = self.client.get("/search/")
 
         self.assertEqual(response.status_code, 200)
@@ -181,6 +266,7 @@ class SearchViewTests(TestCase):
             "최근 업데이트된 문서를 둘러보고, 필요한 경우 바로 검색으로 좁혀갈 수 있습니다.",
         )
         self.assertContains(response, "최근 운영 문서")
+        self.assertContains(response, "최근 공개된 게시글입니다.")
         self.assertNotContains(response, "검색어를 입력해 주세요")
 
     def test_integrated_search_full_page_keeps_query_in_search_input(self):

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -1,10 +1,11 @@
 import logging
+import re
 from urllib.parse import urlencode
 
 from django.contrib import messages
 from django.core.paginator import Paginator
 from django.db import transaction
-from django.db.models import Count, Prefetch, Q
+from django.db.models import Case, Count, IntegerField, Prefetch, Q, Value, When
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -38,7 +39,7 @@ from .models import (
     WikiDocument,
     WikiDocumentStatus,
 )
-from .search import get_wiki_search_results
+from .search import get_post_search_results, get_wiki_search_results
 from .wiki_markdown import strip_leading_title_heading
 
 logger = logging.getLogger(__name__)
@@ -756,7 +757,9 @@ def wiki_bookmark_toggle(request, slug):
 def integrated_search(request):
     query = request.GET.get("q", "").strip()
     is_htmx_request = request.headers.get("HX-Request") == "true"
-    search_results = get_wiki_search_results(query=query, limit=16)
+    wiki_search_results = get_wiki_search_results(query=query, limit=16)
+    post_search_results = get_post_search_results(query=query, limit=12)
+    _attach_linked_wiki_documents(post_search_results["items"])
     template_name = (
         "partials/global_search_results.html"
         if is_htmx_request
@@ -769,8 +772,10 @@ def integrated_search(request):
             "page_heading": "Search",
             "query": query,
             "list_tags": LIST_TAGS,
-            "wiki_items": search_results["items"],
-            "wiki_result_count": search_results["total_count"],
+            "wiki_items": wiki_search_results["items"],
+            "wiki_result_count": wiki_search_results["total_count"],
+            "post_items": post_search_results["items"],
+            "post_result_count": post_search_results["total_count"],
             "show_blank_query_state": is_htmx_request and not query,
         },
     )
@@ -860,6 +865,90 @@ def _community_hot_posts_queryset():
             like_count=Count("post_likes__user", distinct=True),
         )
         .order_by("-comment_count", "-created_at", "-id")
+    )
+
+
+def _community_related_posts_queryset(post):
+    shared_tag_ids = list(post.tags.values_list("pk", flat=True))
+    shared_wiki_document_ids = list(post.wiki_documents.values_list("pk", flat=True))
+    keyword_candidates = re.findall(
+        r"[\w-]{2,}",
+        " ".join(
+            [
+                post.title_cache or "",
+                post.summary_cache or "",
+                post.body_markdown_cache or "",
+            ]
+        ),
+        flags=re.UNICODE,
+    )
+    seen_keywords: set[str] = set()
+    keywords: list[str] = []
+    for keyword in keyword_candidates:
+        normalized_keyword = keyword.casefold()
+        if normalized_keyword in seen_keywords:
+            continue
+        seen_keywords.add(normalized_keyword)
+        keywords.append(keyword)
+        if len(keywords) >= 6:
+            break
+
+    queryset = (
+        Post.objects.filter(status=PostStatus.PUBLISHED, deleted_at__isnull=True)
+        .exclude(pk=post.pk)
+        .select_related("author_user")
+        .prefetch_related("tags", "wiki_documents")
+        .annotate(
+            comment_count=Count(
+                "comments",
+                filter=Q(comments__deleted_at__isnull=True),
+                distinct=True,
+            ),
+            like_count=Count("post_likes__user", distinct=True),
+            shared_tag_count=Count(
+                "tags",
+                filter=Q(tags__in=shared_tag_ids),
+                distinct=True,
+            ),
+            shared_wiki_document_count=Count(
+                "wiki_documents",
+                filter=Q(wiki_documents__in=shared_wiki_document_ids),
+                distinct=True,
+            ),
+        )
+    )
+
+    if keywords:
+        text_match_score = Value(0, output_field=IntegerField())
+        for keyword in keywords:
+            text_match_score += Case(
+                When(
+                    Q(title_cache__icontains=keyword)
+                    | Q(summary_cache__icontains=keyword)
+                    | Q(body_markdown_cache__icontains=keyword),
+                    then=Value(1),
+                ),
+                default=Value(0),
+                output_field=IntegerField(),
+            )
+        queryset = queryset.annotate(text_match_score=text_match_score)
+    else:
+        queryset = queryset.annotate(
+            text_match_score=Value(0, output_field=IntegerField())
+        )
+
+    return queryset.filter(
+        Q(shared_tag_count__gt=0)
+        | Q(shared_wiki_document_count__gt=0)
+        | Q(text_match_score__gt=0)
+    ).order_by(
+        "-shared_wiki_document_count",
+        "-shared_tag_count",
+        "-text_match_score",
+        "-comment_count",
+        "-like_count",
+        "-created_at",
+        "-id",
     )
 
 
@@ -1094,9 +1183,16 @@ def _build_community_detail_context(
     post.is_liked_by_current_user = str(post.pk) in liked_post_ids
     post.is_bookmarked_by_current_user = str(post.pk) in bookmarked_post_ids
     _mark_liked_comments(comments, liked_comment_ids)
-    related_posts = list(
-        _community_hot_posts_queryset().exclude(pk=post.pk).filter(~Q(pk=post.pk))[:4]
-    )
+    related_posts = list(_community_related_posts_queryset(post)[:4])
+    if len(related_posts) < 4:
+        fallback_posts = list(
+            _community_hot_posts_queryset()
+            .exclude(pk=post.pk)
+            .exclude(pk__in=[related_post.pk for related_post in related_posts])[
+                : 4 - len(related_posts)
+            ]
+        )
+        related_posts.extend(fallback_posts)
     _attach_linked_wiki_documents(related_posts)
     post_edit_form = post_edit_form or PostForm(
         initial=_build_post_form_initial_from_post(post),

--- a/templates/pages/community/detail.html
+++ b/templates/pages/community/detail.html
@@ -127,7 +127,7 @@
                     </section>
                 {% endif %}
                 <section class="rounded-[2rem] bg-surface-container-low p-6">
-                    <div class="text-sm font-semibold text-primary">핫게시글</div>
+                    <div class="text-sm font-semibold text-primary">연관 게시글</div>
                     <div class="mt-4 space-y-4">
                         {% for item in related_posts %}
                             <a href="{{ item.url }}"

--- a/templates/pages/search/results.html
+++ b/templates/pages/search/results.html
@@ -4,7 +4,7 @@
 {% endblock title %}
 {% block app_content %}
     <section class="mx-auto max-w-7xl space-y-8">
-        {% include "partials/section_header.html" with eyebrow="Search" title="문서 검색" description="현재는 위키 문서를 기준으로 검색 결과를 보여줍니다." %}
+        {% include "partials/section_header.html" with eyebrow="Search" title="통합 검색" description="위키 문서와 커뮤니티 게시글을 한 화면에서 함께 검색합니다." %}
         <div class="max-w-3xl">
             {% include "partials/search_bar.html" with placeholder="찾고 싶은 위키 문서를 검색하세요" action="/search/" value=query %}
         </div>

--- a/templates/partials/global_search_results.html
+++ b/templates/partials/global_search_results.html
@@ -6,36 +6,66 @@
             <div class="rounded-[1.75rem] bg-surface-container-low px-5 py-4 text-sm text-on-surface-variant">
                 <span>검색어</span>
                 <span class="ml-2 font-semibold text-on-surface">{{ query }}</span>
-                <span class="ml-3 text-stone-400">문서 {{ wiki_result_count }}건</span>
+                <span class="ml-3 text-stone-400">문서 {{ wiki_result_count }}건 · 게시글 {{ post_result_count }}건</span>
             </div>
         {% endif %}
-        <section class="space-y-4">
-            <div class="flex flex-wrap items-center justify-between gap-3">
-                <div>
-                    <h3 class="font-headline text-2xl font-extrabold tracking-tight">위키 문서</h3>
-                    <p class="mt-2 text-sm leading-7 text-on-surface-variant">
-                        {% if query %}
-                            제목, 요약, 본문에서 일치하는 결과입니다.
-                        {% else %}
-                            최근 업데이트된 문서를 둘러보고, 필요한 경우 바로 검색으로 좁혀갈 수 있습니다.
-                        {% endif %}
-                    </p>
+        <div class="grid gap-6 lg:grid-cols-2">
+            <section class="space-y-4">
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                        <h3 class="font-headline text-2xl font-extrabold tracking-tight">위키 문서</h3>
+                        <p class="mt-2 text-sm leading-7 text-on-surface-variant">
+                            {% if query %}
+                                제목, 요약, 본문에서 일치하는 결과입니다.
+                            {% else %}
+                                최근 업데이트된 문서를 둘러보고, 필요한 경우 바로 검색으로 좁혀갈 수 있습니다.
+                            {% endif %}
+                        </p>
+                    </div>
+                    <div class="rounded-full bg-surface-container-high px-4 py-2 text-sm font-semibold text-on-surface-variant">
+                        {{ wiki_result_count }}건
+                    </div>
                 </div>
-                <div class="rounded-full bg-surface-container-high px-4 py-2 text-sm font-semibold text-on-surface-variant">
-                    {{ wiki_result_count }}건
+                {% if wiki_items %}
+                    <div class="grid gap-5">
+                        {% for item in wiki_items %}
+                            {% include "partials/wiki_card.html" %}
+                        {% endfor %}
+                    </div>
+                {% elif query %}
+                    {% include "partials/empty_state.html" with title="문서 결과가 없습니다" description="다른 검색어로 다시 시도해 보세요." %}
+                {% else %}
+                    {% include "partials/empty_state.html" with title="최근 문서가 없습니다" description="문서가 쌓이면 이곳에서 최근 업데이트 항목을 바로 확인할 수 있습니다." %}
+                {% endif %}
+            </section>
+            <section class="space-y-4">
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                        <h3 class="font-headline text-2xl font-extrabold tracking-tight">게시글</h3>
+                        <p class="mt-2 text-sm leading-7 text-on-surface-variant">
+                            {% if query %}
+                                제목, 요약, 본문, 태그, 연결된 위키에서 일치하는 결과입니다.
+                            {% else %}
+                                최근 공개된 커뮤니티 게시글을 함께 확인할 수 있습니다.
+                            {% endif %}
+                        </p>
+                    </div>
+                    <div class="rounded-full bg-surface-container-high px-4 py-2 text-sm font-semibold text-on-surface-variant">
+                        {{ post_result_count }}건
+                    </div>
                 </div>
-            </div>
-            {% if wiki_items %}
-                <div class="grid gap-5 lg:grid-cols-2">
-                    {% for item in wiki_items %}
-                        {% include "partials/wiki_card.html" %}
-                    {% endfor %}
-                </div>
-            {% elif query %}
-                {% include "partials/empty_state.html" with title="검색 결과가 없습니다" description="검색어를 바꾸거나 더 일반적인 표현으로 다시 시도해 보세요." %}
-            {% else %}
-                {% include "partials/empty_state.html" with title="최근 문서가 없습니다" description="문서가 쌓이면 이곳에서 최근 업데이트 항목을 바로 확인할 수 있습니다." %}
-            {% endif %}
-        </section>
+                {% if post_items %}
+                    <div class="space-y-2">
+                        {% for item in post_items %}
+                            {% include "partials/post_card.html" %}
+                        {% endfor %}
+                    </div>
+                {% elif query %}
+                    {% include "partials/empty_state.html" with title="게시글 결과가 없습니다" description="태그나 핵심 용어로 다시 검색해 보세요." %}
+                {% else %}
+                    {% include "partials/empty_state.html" with title="최근 게시글이 없습니다" description="새로운 논의가 생기면 이곳에서 함께 보여줍니다." %}
+                {% endif %}
+            </section>
+        </div>
     {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- add published community posts to integrated search alongside wiki documents
- improve community detail related-post ranking using shared tags, linked wiki documents, and text matches
- update search and community tests, including test-only staticfiles storage overrides for local stability

## Testing
- nix develop --command python manage.py test apps.core.tests.test_search_views
- nix develop --command python manage.py test apps.core.tests.test_community_views.CommunityViewTests.test_community_detail_prioritizes_related_posts_over_hot_posts --keepdb