### PR TITLE
feat: improve admin ingestion management

### DIFF
--- a/apps/core/tests/test_admin_console.py
+++ b/apps/core/tests/test_admin_console.py
@@ -15,10 +15,13 @@ from apps.accounts.models import (
 from apps.accounts.services import SESSION_USER_ID_KEY
 from apps.core.models import (
     IngestionJob,
+    IngestionJobStatus,
     Post,
     PostStatus,
     Source,
     SourceDocument,
+    SourceDocumentFetchStatus,
+    SourceDocumentWikiStatus,
     Tag,
     TagType,
     WikiDocument,
@@ -788,6 +791,147 @@ class AdminConsoleTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Paused")
         self.assertContains(response, "중지 소스")
+
+    def test_admin_ingestion_management_filters_sources_by_query_and_health(self):
+        admin_user = HiveUser.objects.create(
+            username="admin_user",
+            email="admin@example.com",
+            password_hash=make_password("admin-pass-123!"),
+            role=UserRole.ADMIN,
+            status=UserStatus.ACTIVE,
+        )
+        Source.objects.create(
+            name="공지 RSS",
+            target_url="https://example.com/announcements",
+            enabled=True,
+            poll_interval_minutes=15,
+            next_poll_at=timezone.now(),
+            updated_at=timezone.now(),
+        )
+        Source.objects.create(
+            name="실패 RSS",
+            target_url="https://example.com/failing",
+            enabled=True,
+            poll_interval_minutes=15,
+            next_poll_at=timezone.now(),
+            consecutive_failures=2,
+            last_error_message="fetch failed",
+            updated_at=timezone.now(),
+        )
+        self._login(admin_user)
+
+        response = self.client.get(
+            "/dashboard/admin/ingestion/",
+            {
+                "section": "sources",
+                "source_query": "RSS",
+                "source_health": "failing",
+            },
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "실패 RSS")
+        self.assertNotContains(response, "공지 RSS")
+
+    def test_admin_ingestion_management_filters_documents_and_jobs_with_htmx(self):
+        admin_user = HiveUser.objects.create(
+            username="admin_user",
+            email="admin@example.com",
+            password_hash=make_password("admin-pass-123!"),
+            role=UserRole.ADMIN,
+            status=UserStatus.ACTIVE,
+        )
+        source = Source.objects.create(
+            name="교내 공지",
+            target_url="https://example.com/announcements",
+            enabled=True,
+            poll_interval_minutes=15,
+            next_poll_at=timezone.now(),
+            updated_at=timezone.now(),
+        )
+        matching_document = SourceDocument.objects.create(
+            source=source,
+            canonical_url="https://example.com/doc-1",
+            title="장학금 공지",
+            fetch_status=SourceDocumentFetchStatus.FAILED,
+            wiki_status=SourceDocumentWikiStatus.REQUESTED,
+        )
+        other_document = SourceDocument.objects.create(
+            source=source,
+            canonical_url="https://example.com/doc-2",
+            title="기숙사 안내",
+            fetch_status=SourceDocumentFetchStatus.FETCHED,
+            wiki_status=SourceDocumentWikiStatus.COMPLETED,
+        )
+        IngestionJob.objects.create(
+            source_document=matching_document,
+            status=IngestionJobStatus.FAILED,
+            error_message="timeout",
+        )
+        other_document.ingestion_jobs.create(
+            status=IngestionJobStatus.COMPLETED,
+            error_message="",
+        )
+        self._login(admin_user)
+
+        document_response = self.client.get(
+            "/dashboard/admin/ingestion/",
+            {
+                "section": "recent_documents",
+                "document_query": "장학금",
+                "document_fetch_status": SourceDocumentFetchStatus.FAILED,
+            },
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(document_response.status_code, 200)
+        self.assertContains(document_response, "장학금 공지")
+        self.assertNotContains(document_response, "기숙사 안내")
+
+        job_response = self.client.get(
+            "/dashboard/admin/ingestion/",
+            {
+                "section": "recent_jobs",
+                "job_query": "timeout",
+                "job_status": IngestionJobStatus.FAILED,
+            },
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(job_response.status_code, 200)
+        self.assertContains(job_response, "장학금 공지")
+        self.assertNotContains(job_response, "기숙사 안내")
+
+    def test_admin_ingestion_management_paginates_sources_panel(self):
+        admin_user = HiveUser.objects.create(
+            username="admin_user",
+            email="admin@example.com",
+            password_hash=make_password("admin-pass-123!"),
+            role=UserRole.ADMIN,
+            status=UserStatus.ACTIVE,
+        )
+        for index in range(7):
+            Source.objects.create(
+                name=f"소스 {index}",
+                target_url=f"https://example.com/{index}",
+                enabled=True,
+                poll_interval_minutes=15,
+                next_poll_at=timezone.now(),
+                updated_at=timezone.now(),
+            )
+        self._login(admin_user)
+
+        response = self.client.get(
+            "/dashboard/admin/ingestion/",
+            {"section": "sources", "source_page": 2},
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "소스 6")
+        self.assertNotContains(response, "소스 0")
+        self.assertContains(response, "2 / 2")
 
     def test_admin_content_management_lists_posts_and_wiki_documents(self):
         admin_user = HiveUser.objects.create(

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -28,12 +28,15 @@ from .models import (
     Comment,
     CommentLike,
     IngestionJob,
+    IngestionJobStatus,
     Post,
     PostBookmark,
     PostLike,
     PostStatus,
     Source,
     SourceDocument,
+    SourceDocumentFetchStatus,
+    SourceDocumentWikiStatus,
     Tag,
     WikiBookmark,
     WikiDocument,
@@ -46,6 +49,9 @@ logger = logging.getLogger(__name__)
 COMMUNITY_FEED_PAGE_SIZE = 10
 ADMIN_CONTENT_POST_PAGE_SIZE = 6
 ADMIN_CONTENT_WIKI_PAGE_SIZE = 6
+ADMIN_INGESTION_SOURCE_PAGE_SIZE = 6
+ADMIN_INGESTION_DOCUMENT_PAGE_SIZE = 8
+ADMIN_INGESTION_JOB_PAGE_SIZE = 8
 
 ADMIN_USER_ACTIONS = frozenset(
     {
@@ -1496,6 +1502,23 @@ def _build_admin_content_url(request, **updates):
     return f"{request.path}?{query}"
 
 
+def _build_admin_ingestion_querystring(request, **updates):
+    params = request.GET.copy()
+    for key, value in updates.items():
+        if value in ("", None):
+            params.pop(key, None)
+        else:
+            params[key] = value
+    return params.urlencode()
+
+
+def _build_admin_ingestion_url(request, **updates):
+    query = _build_admin_ingestion_querystring(request, **updates)
+    if not query:
+        return request.path
+    return f"{request.path}?{query}"
+
+
 @login_required
 @admin_required
 def admin_console(request):
@@ -1633,6 +1656,17 @@ def admin_ingestion_management(request):
     else:
         source_form = SourceForm()
 
+    source_query = request.GET.get("source_query", "").strip()
+    selected_source_health = request.GET.get("source_health", "").strip()
+    selected_source_enabled = request.GET.get("source_enabled", "").strip()
+    document_query = request.GET.get("document_query", "").strip()
+    selected_document_fetch_status = request.GET.get(
+        "document_fetch_status", ""
+    ).strip()
+    selected_document_wiki_status = request.GET.get("document_wiki_status", "").strip()
+    job_query = request.GET.get("job_query", "").strip()
+    selected_job_status = request.GET.get("job_status", "").strip()
+
     source_queryset = Source.objects.annotate(
         document_count=Count("documents", distinct=True),
         pending_document_count=Count(
@@ -1655,34 +1689,145 @@ def admin_ingestion_management(request):
             filter=Q(documents__ingestion_jobs__status="FAILED"),
             distinct=True,
         ),
-    ).order_by("name")
-    recent_documents = list(
-        SourceDocument.objects.select_related("source").order_by("-collected_at")[:8]
     )
-    recent_jobs = list(
-        IngestionJob.objects.select_related(
-            "source_document", "source_document__source"
-        ).order_by("-queued_at")[:8]
+    if source_query:
+        source_queryset = source_queryset.filter(
+            Q(name__icontains=source_query) | Q(target_url__icontains=source_query)
+        )
+    if selected_source_enabled == "enabled":
+        source_queryset = source_queryset.filter(enabled=True)
+    elif selected_source_enabled == "disabled":
+        source_queryset = source_queryset.filter(enabled=False)
+    if selected_source_health == "healthy":
+        source_queryset = source_queryset.filter(
+            enabled=True,
+            consecutive_failures=0,
+            failed_document_count=0,
+            failed_job_count=0,
+            pending_document_count=0,
+            queued_job_count=0,
+        ).filter(Q(last_error_message__isnull=True) | Q(last_error_message=""))
+    elif selected_source_health == "warning":
+        source_queryset = source_queryset.filter(
+            enabled=True,
+            consecutive_failures=0,
+            failed_document_count=0,
+            failed_job_count=0,
+        ).filter(Q(last_error_message__isnull=True) | Q(last_error_message=""))
+        source_queryset = source_queryset.filter(
+            Q(pending_document_count__gt=0) | Q(queued_job_count__gt=0)
+        )
+    elif selected_source_health == "failing":
+        source_queryset = source_queryset.filter(enabled=True).filter(
+            Q(consecutive_failures__gt=0)
+            | Q(failed_document_count__gt=0)
+            | Q(failed_job_count__gt=0)
+            | (Q(last_error_message__isnull=False) & ~Q(last_error_message=""))
+        )
+    elif selected_source_health == "paused":
+        source_queryset = source_queryset.filter(enabled=False)
+    source_queryset = source_queryset.order_by("name").distinct()
+
+    recent_documents_queryset = SourceDocument.objects.select_related(
+        "source"
+    ).order_by("-collected_at")
+    if document_query:
+        recent_documents_queryset = recent_documents_queryset.filter(
+            Q(title__icontains=document_query)
+            | Q(canonical_url__icontains=document_query)
+            | Q(source__name__icontains=document_query)
+        )
+    if selected_document_fetch_status in {
+        SourceDocumentFetchStatus.PENDING,
+        SourceDocumentFetchStatus.FETCHED,
+        SourceDocumentFetchStatus.FAILED,
+    }:
+        recent_documents_queryset = recent_documents_queryset.filter(
+            fetch_status=selected_document_fetch_status
+        )
+    if selected_document_wiki_status in {
+        SourceDocumentWikiStatus.NOT_REQUESTED,
+        SourceDocumentWikiStatus.REQUESTED,
+        SourceDocumentWikiStatus.COMPLETED,
+        SourceDocumentWikiStatus.FAILED,
+    }:
+        recent_documents_queryset = recent_documents_queryset.filter(
+            wiki_status=selected_document_wiki_status
+        )
+
+    recent_jobs_queryset = IngestionJob.objects.select_related(
+        "source_document", "source_document__source"
+    ).order_by("-queued_at")
+    if job_query:
+        recent_jobs_queryset = recent_jobs_queryset.filter(
+            Q(source_document__title__icontains=job_query)
+            | Q(source_document__canonical_url__icontains=job_query)
+            | Q(source_document__source__name__icontains=job_query)
+            | Q(error_message__icontains=job_query)
+        )
+    if selected_job_status in {
+        IngestionJobStatus.QUEUED,
+        IngestionJobStatus.STARTED,
+        IngestionJobStatus.COMPLETED,
+        IngestionJobStatus.FAILED,
+    }:
+        recent_jobs_queryset = recent_jobs_queryset.filter(status=selected_job_status)
+
+    source_paginator = Paginator(source_queryset, ADMIN_INGESTION_SOURCE_PAGE_SIZE)
+    source_page_obj = source_paginator.get_page(request.GET.get("source_page") or 1)
+    sources = source_page_obj
+    document_paginator = Paginator(
+        recent_documents_queryset, ADMIN_INGESTION_DOCUMENT_PAGE_SIZE
     )
-    sources = list(source_queryset)
+    recent_documents = document_paginator.get_page(
+        request.GET.get("document_page") or 1
+    )
+    job_paginator = Paginator(recent_jobs_queryset, ADMIN_INGESTION_JOB_PAGE_SIZE)
+    recent_jobs = job_paginator.get_page(request.GET.get("job_page") or 1)
+
+    health_count_queryset = Source.objects.annotate(
+        pending_document_count=Count(
+            "documents",
+            filter=Q(documents__fetch_status=SourceDocumentFetchStatus.PENDING),
+            distinct=True,
+        ),
+        failed_document_count=Count(
+            "documents",
+            filter=Q(documents__fetch_status=SourceDocumentFetchStatus.FAILED),
+            distinct=True,
+        ),
+        queued_job_count=Count(
+            "documents__ingestion_jobs",
+            filter=Q(documents__ingestion_jobs__status=IngestionJobStatus.QUEUED),
+            distinct=True,
+        ),
+        failed_job_count=Count(
+            "documents__ingestion_jobs",
+            filter=Q(documents__ingestion_jobs__status=IngestionJobStatus.FAILED),
+            distinct=True,
+        ),
+    )
     healthy_source_count = 0
     paused_source_count = 0
     warning_source_count = 0
     failing_source_count = 0
+    for source in health_count_queryset:
+        health = _classify_source_health(source)
+        if health["status"] == "healthy":
+            healthy_source_count += 1
+        elif health["status"] == "paused":
+            paused_source_count += 1
+        elif health["status"] == "warning":
+            warning_source_count += 1
+        else:
+            failing_source_count += 1
+
     for source in sources:
         health = _classify_source_health(source)
         source.health_status = health["status"]
         source.health_label = health["label"]
         source.health_badge_class = health["badge_class"]
         source.health_panel_class = health["panel_class"]
-        if source.health_status == "healthy":
-            healthy_source_count += 1
-        elif source.health_status == "paused":
-            paused_source_count += 1
-        elif source.health_status == "warning":
-            warning_source_count += 1
-        else:
-            failing_source_count += 1
 
     context = {
         **_build_admin_summary_context(),
@@ -1692,9 +1837,116 @@ def admin_ingestion_management(request):
         "sources": sources,
         "recent_documents": recent_documents,
         "recent_jobs": recent_jobs,
+        "source_query": source_query,
+        "selected_source_health": selected_source_health,
+        "selected_source_enabled": selected_source_enabled,
+        "document_query": document_query,
+        "selected_document_fetch_status": selected_document_fetch_status,
+        "selected_document_wiki_status": selected_document_wiki_status,
+        "job_query": job_query,
+        "selected_job_status": selected_job_status,
+        "source_health_choices": [
+            ("", "전체 상태"),
+            ("healthy", "Healthy"),
+            ("warning", "Warning"),
+            ("failing", "Failing"),
+            ("paused", "Paused"),
+        ],
+        "source_enabled_choices": [
+            ("", "활성/비활성 전체"),
+            ("enabled", "활성만"),
+            ("disabled", "비활성만"),
+        ],
+        "document_fetch_status_choices": [
+            ("", "fetch 전체"),
+            (SourceDocumentFetchStatus.PENDING, "Pending"),
+            (SourceDocumentFetchStatus.FETCHED, "Fetched"),
+            (SourceDocumentFetchStatus.FAILED, "Failed"),
+        ],
+        "document_wiki_status_choices": [
+            ("", "wiki 전체"),
+            (SourceDocumentWikiStatus.NOT_REQUESTED, "Not requested"),
+            (SourceDocumentWikiStatus.REQUESTED, "Requested"),
+            (SourceDocumentWikiStatus.COMPLETED, "Completed"),
+            (SourceDocumentWikiStatus.FAILED, "Failed"),
+        ],
+        "job_status_choices": [
+            ("", "잡 상태 전체"),
+            (IngestionJobStatus.QUEUED, "Queued"),
+            (IngestionJobStatus.STARTED, "Started"),
+            (IngestionJobStatus.COMPLETED, "Completed"),
+            (IngestionJobStatus.FAILED, "Failed"),
+        ],
+        "source_prev_url": (
+            _build_admin_ingestion_url(
+                request,
+                section="sources",
+                source_page=source_page_obj.previous_page_number(),
+            )
+            if source_page_obj.has_previous()
+            else ""
+        ),
+        "source_next_url": (
+            _build_admin_ingestion_url(
+                request,
+                section="sources",
+                source_page=source_page_obj.next_page_number(),
+            )
+            if source_page_obj.has_next()
+            else ""
+        ),
+        "document_prev_url": (
+            _build_admin_ingestion_url(
+                request,
+                section="recent_documents",
+                document_page=recent_documents.previous_page_number(),
+            )
+            if recent_documents.has_previous()
+            else ""
+        ),
+        "document_next_url": (
+            _build_admin_ingestion_url(
+                request,
+                section="recent_documents",
+                document_page=recent_documents.next_page_number(),
+            )
+            if recent_documents.has_next()
+            else ""
+        ),
+        "job_prev_url": (
+            _build_admin_ingestion_url(
+                request,
+                section="recent_jobs",
+                job_page=recent_jobs.previous_page_number(),
+            )
+            if recent_jobs.has_previous()
+            else ""
+        ),
+        "job_next_url": (
+            _build_admin_ingestion_url(
+                request,
+                section="recent_jobs",
+                job_page=recent_jobs.next_page_number(),
+            )
+            if recent_jobs.has_next()
+            else ""
+        ),
+        "sources_refresh_query": _build_admin_ingestion_querystring(
+            request, section="sources"
+        ),
+        "documents_refresh_query": _build_admin_ingestion_querystring(
+            request, section="recent_documents"
+        ),
+        "jobs_refresh_query": _build_admin_ingestion_querystring(
+            request, section="recent_jobs"
+        ),
         "document_count": SourceDocument.objects.count(),
-        "queued_job_count": IngestionJob.objects.filter(status="QUEUED").count(),
-        "failed_job_count": IngestionJob.objects.filter(status="FAILED").count(),
+        "queued_job_count": IngestionJob.objects.filter(
+            status=IngestionJobStatus.QUEUED
+        ).count(),
+        "failed_job_count": IngestionJob.objects.filter(
+            status=IngestionJobStatus.FAILED
+        ).count(),
         "healthy_source_count": healthy_source_count,
         "paused_source_count": paused_source_count,
         "warning_source_count": warning_source_count,

--- a/templates/partials/admin/ingestion_documents_panel.html
+++ b/templates/partials/admin/ingestion_documents_panel.html
@@ -1,6 +1,49 @@
 <div id="admin-ingestion-documents"
      class="space-y-5 rounded-[2rem] bg-surface-container-low p-6 shadow-ambient lg:p-8">
-    {% include "partials/section_header.html" with eyebrow="Recent Documents" title="최근 수집 문서" description="어떤 소스에서 문서가 들어왔는지와 fetch/wiki 상태를 같이 봅니다." refresh_url=request.path refresh_section="recent_documents" refresh_target="#admin-ingestion-documents" %}
+    {% include "partials/section_header.html" with eyebrow="Recent Documents" title="최근 수집 문서" description="어떤 소스에서 문서가 들어왔는지와 fetch/wiki 상태를 같이 봅니다." refresh_url=request.path refresh_query=documents_refresh_query refresh_section="recent_documents" refresh_target="#admin-ingestion-documents" %}
+    <form method="get"
+          action="{{ request.path }}"
+          hx-get="{{ request.path }}"
+          hx-target="#admin-ingestion-documents"
+          hx-swap="outerHTML"
+          hx-push-url="true"
+          class="grid gap-3 rounded-[1.5rem] bg-white p-4 lg:grid-cols-[minmax(0,1.2fr)_180px] xl:grid-cols-[minmax(0,1.2fr)_180px_180px_auto]">
+        <input type="hidden" name="section" value="recent_documents">
+        <input type="hidden" name="source_query" value="{{ source_query }}">
+        <input type="hidden"
+               name="source_health"
+               value="{{ selected_source_health }}">
+        <input type="hidden"
+               name="source_enabled"
+               value="{{ selected_source_enabled }}">
+        <input type="hidden" name="source_page" value="{{ sources.number }}">
+        <input type="hidden" name="job_query" value="{{ job_query }}">
+        <input type="hidden" name="job_status" value="{{ selected_job_status }}">
+        <input type="hidden" name="job_page" value="{{ recent_jobs.number }}">
+        <input type="search"
+               name="document_query"
+               value="{{ document_query }}"
+               placeholder="문서 제목, URL, 소스 검색"
+               class="min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant focus:ring-2 focus:ring-primary-container">
+        <select name="document_fetch_status"
+                class="min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface focus:ring-2 focus:ring-primary-container">
+            {% for value, label in document_fetch_status_choices %}
+                <option value="{{ value }}"
+                        {% if selected_document_fetch_status == value %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+        </select>
+        <select name="document_wiki_status"
+                class="min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface focus:ring-2 focus:ring-primary-container">
+            {% for value, label in document_wiki_status_choices %}
+                <option value="{{ value }}"
+                        {% if selected_document_wiki_status == value %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+        </select>
+        <button type="submit"
+                class="whitespace-nowrap rounded-2xl bg-primary-container px-4 py-3 text-sm font-semibold text-on-primary-container">
+            적용
+        </button>
+    </form>
     <div class="space-y-3">
         {% for document in recent_documents %}
             <article class="rounded-[1.5rem] bg-white px-5 py-5">
@@ -22,4 +65,29 @@
             <div class="rounded-[1.5rem] bg-white px-5 py-8 text-sm text-on-surface-variant">수집된 문서가 없습니다.</div>
         {% endfor %}
     </div>
+    {% if recent_documents.paginator.num_pages > 1 %}
+        <div class="flex items-center justify-between gap-4 border-t border-outline-variant/70 pt-5 text-sm">
+            {% if recent_documents.has_previous %}
+                <a href="{{ document_prev_url }}"
+                   hx-get="{{ document_prev_url }}"
+                   hx-target="#admin-ingestion-documents"
+                   hx-swap="outerHTML"
+                   hx-push-url="true"
+                   class="rounded-2xl bg-surface-container-high px-4 py-2 font-semibold text-primary">이전</a>
+            {% else %}
+                <span class="rounded-2xl bg-surface-container-high px-4 py-2 text-on-surface-variant">이전</span>
+            {% endif %}
+            <span class="text-on-surface-variant">{{ recent_documents.number }} / {{ recent_documents.paginator.num_pages }}</span>
+            {% if recent_documents.has_next %}
+                <a href="{{ document_next_url }}"
+                   hx-get="{{ document_next_url }}"
+                   hx-target="#admin-ingestion-documents"
+                   hx-swap="outerHTML"
+                   hx-push-url="true"
+                   class="rounded-2xl bg-surface-container-high px-4 py-2 font-semibold text-primary">다음</a>
+            {% else %}
+                <span class="rounded-2xl bg-surface-container-high px-4 py-2 text-on-surface-variant">다음</span>
+            {% endif %}
+        </div>
+    {% endif %}
 </div>

--- a/templates/partials/admin/ingestion_jobs_panel.html
+++ b/templates/partials/admin/ingestion_jobs_panel.html
@@ -1,6 +1,49 @@
 <div id="admin-ingestion-jobs"
      class="space-y-5 rounded-[2rem] bg-surface-container-low p-6 shadow-ambient lg:p-8">
-    {% include "partials/section_header.html" with eyebrow="Recent Jobs" title="최근 ingestion job" description="큐에 들어간 작업과 실패 메시지를 빠르게 확인합니다." refresh_url=request.path refresh_section="recent_jobs" refresh_target="#admin-ingestion-jobs" %}
+    {% include "partials/section_header.html" with eyebrow="Recent Jobs" title="최근 ingestion job" description="큐에 들어간 작업과 실패 메시지를 빠르게 확인합니다." refresh_url=request.path refresh_query=jobs_refresh_query refresh_section="recent_jobs" refresh_target="#admin-ingestion-jobs" %}
+    <form method="get"
+          action="{{ request.path }}"
+          hx-get="{{ request.path }}"
+          hx-target="#admin-ingestion-jobs"
+          hx-swap="outerHTML"
+          hx-push-url="true"
+          class="grid gap-3 rounded-[1.5rem] bg-white p-4 lg:grid-cols-[minmax(0,1.2fr)_220px_auto]">
+        <input type="hidden" name="section" value="recent_jobs">
+        <input type="hidden" name="source_query" value="{{ source_query }}">
+        <input type="hidden"
+               name="source_health"
+               value="{{ selected_source_health }}">
+        <input type="hidden"
+               name="source_enabled"
+               value="{{ selected_source_enabled }}">
+        <input type="hidden" name="source_page" value="{{ sources.number }}">
+        <input type="hidden" name="document_query" value="{{ document_query }}">
+        <input type="hidden"
+               name="document_fetch_status"
+               value="{{ selected_document_fetch_status }}">
+        <input type="hidden"
+               name="document_wiki_status"
+               value="{{ selected_document_wiki_status }}">
+        <input type="hidden"
+               name="document_page"
+               value="{{ recent_documents.number }}">
+        <input type="search"
+               name="job_query"
+               value="{{ job_query }}"
+               placeholder="문서 제목, URL, 에러 메시지 검색"
+               class="min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant focus:ring-2 focus:ring-primary-container">
+        <select name="job_status"
+                class="min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface focus:ring-2 focus:ring-primary-container">
+            {% for value, label in job_status_choices %}
+                <option value="{{ value }}"
+                        {% if selected_job_status == value %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+        </select>
+        <button type="submit"
+                class="whitespace-nowrap rounded-2xl bg-primary-container px-4 py-3 text-sm font-semibold text-on-primary-container lg:justify-self-start">
+            적용
+        </button>
+    </form>
     <div class="space-y-3">
         {% for job in recent_jobs %}
             <article class="rounded-[1.5rem] bg-white px-5 py-5">
@@ -47,4 +90,29 @@
             <div class="rounded-[1.5rem] bg-white px-5 py-8 text-sm text-on-surface-variant">생성된 ingestion job이 없습니다.</div>
         {% endfor %}
     </div>
+    {% if recent_jobs.paginator.num_pages > 1 %}
+        <div class="flex items-center justify-between gap-4 border-t border-outline-variant/70 pt-5 text-sm">
+            {% if recent_jobs.has_previous %}
+                <a href="{{ job_prev_url }}"
+                   hx-get="{{ job_prev_url }}"
+                   hx-target="#admin-ingestion-jobs"
+                   hx-swap="outerHTML"
+                   hx-push-url="true"
+                   class="rounded-2xl bg-surface-container-high px-4 py-2 font-semibold text-primary">이전</a>
+            {% else %}
+                <span class="rounded-2xl bg-surface-container-high px-4 py-2 text-on-surface-variant">이전</span>
+            {% endif %}
+            <span class="text-on-surface-variant">{{ recent_jobs.number }} / {{ recent_jobs.paginator.num_pages }}</span>
+            {% if recent_jobs.has_next %}
+                <a href="{{ job_next_url }}"
+                   hx-get="{{ job_next_url }}"
+                   hx-target="#admin-ingestion-jobs"
+                   hx-swap="outerHTML"
+                   hx-push-url="true"
+                   class="rounded-2xl bg-surface-container-high px-4 py-2 font-semibold text-primary">다음</a>
+            {% else %}
+                <span class="rounded-2xl bg-surface-container-high px-4 py-2 text-on-surface-variant">다음</span>
+            {% endif %}
+        </div>
+    {% endif %}
 </div>

--- a/templates/partials/admin/ingestion_sources_panel.html
+++ b/templates/partials/admin/ingestion_sources_panel.html
@@ -1,15 +1,62 @@
 <div id="admin-ingestion-sources"
      class="space-y-6 rounded-[2rem] bg-surface-container-low p-6 shadow-ambient lg:p-8">
-    {% include "partials/section_header.html" with eyebrow="Verbose Status" title="소스별 수집 현황" description="소스, 문서, 잡 상태를 한 번에 보고 문제가 생긴 구간을 빠르게 좁힙니다." refresh_url=request.path refresh_section="sources" refresh_target="#admin-ingestion-sources" %}
+    {% include "partials/section_header.html" with eyebrow="Verbose Status" title="소스별 수집 현황" description="소스, 문서, 잡 상태를 한 번에 보고 문제가 생긴 구간을 빠르게 좁힙니다." refresh_url=request.path refresh_query=sources_refresh_query refresh_section="sources" refresh_target="#admin-ingestion-sources" %}
+    <form method="get"
+          action="{{ request.path }}"
+          hx-get="{{ request.path }}"
+          hx-target="#admin-ingestion-sources"
+          hx-swap="outerHTML"
+          hx-push-url="true"
+          class="space-y-3 rounded-[1.5rem] bg-white p-4">
+        <input type="hidden" name="section" value="sources">
+        <input type="hidden" name="document_query" value="{{ document_query }}">
+        <input type="hidden"
+               name="document_fetch_status"
+               value="{{ selected_document_fetch_status }}">
+        <input type="hidden"
+               name="document_wiki_status"
+               value="{{ selected_document_wiki_status }}">
+        <input type="hidden"
+               name="document_page"
+               value="{{ recent_documents.number }}">
+        <input type="hidden" name="job_query" value="{{ job_query }}">
+        <input type="hidden" name="job_status" value="{{ selected_job_status }}">
+        <input type="hidden" name="job_page" value="{{ recent_jobs.number }}">
+        <input type="search"
+               name="source_query"
+               value="{{ source_query }}"
+               placeholder="소스 이름, URL 검색"
+               class="w-full min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant focus:ring-2 focus:ring-primary-container">
+        <div class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+            <select name="source_health"
+                    class="w-full min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface focus:ring-2 focus:ring-primary-container">
+                {% for value, label in source_health_choices %}
+                    <option value="{{ value }}"
+                            {% if selected_source_health == value %}selected{% endif %}>{{ label }}</option>
+                {% endfor %}
+            </select>
+            <select name="source_enabled"
+                    class="w-full min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface focus:ring-2 focus:ring-primary-container">
+                {% for value, label in source_enabled_choices %}
+                    <option value="{{ value }}"
+                            {% if selected_source_enabled == value %}selected{% endif %}>{{ label }}</option>
+                {% endfor %}
+            </select>
+            <button type="submit"
+                    class="whitespace-nowrap rounded-2xl bg-primary-container px-4 py-3 text-sm font-semibold text-on-primary-container">
+                적용
+            </button>
+        </div>
+    </form>
     <div class="space-y-3">
         {% for source in sources %}
             <div class="rounded-[1.5rem] bg-white px-5 py-5 transition hover:-translate-y-0.5 hover:shadow-ambient {{ source.health_panel_class }}">
-                <div class="flex items-start justify-between gap-4">
-                    <div>
+                <div class="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+                    <div class="min-w-0">
                         <div class="font-semibold text-on-surface">{{ source.name }}</div>
                         <div class="mt-1 break-all text-xs text-stone-500">{{ source.target_url }}</div>
                     </div>
-                    <div class="flex items-center gap-3">
+                    <div class="flex shrink-0 flex-wrap items-center gap-3 xl:justify-end">
                         <div class="rounded-full px-3 py-1 text-xs font-semibold {{ source.health_badge_class }}">
                             {{ source.health_label }}
                         </div>
@@ -91,4 +138,29 @@
             <div class="rounded-[1.5rem] bg-white px-5 py-8 text-sm text-on-surface-variant">등록된 수집 소스가 없습니다.</div>
         {% endfor %}
     </div>
+    {% if sources.paginator.num_pages > 1 %}
+        <div class="flex items-center justify-between gap-4 border-t border-outline-variant/70 pt-5 text-sm">
+            {% if sources.has_previous %}
+                <a href="{{ source_prev_url }}"
+                   hx-get="{{ source_prev_url }}"
+                   hx-target="#admin-ingestion-sources"
+                   hx-swap="outerHTML"
+                   hx-push-url="true"
+                   class="rounded-2xl bg-surface-container-high px-4 py-2 font-semibold text-primary">이전</a>
+            {% else %}
+                <span class="rounded-2xl bg-surface-container-high px-4 py-2 text-on-surface-variant">이전</span>
+            {% endif %}
+            <span class="text-on-surface-variant">{{ sources.number }} / {{ sources.paginator.num_pages }}</span>
+            {% if sources.has_next %}
+                <a href="{{ source_next_url }}"
+                   hx-get="{{ source_next_url }}"
+                   hx-target="#admin-ingestion-sources"
+                   hx-swap="outerHTML"
+                   hx-push-url="true"
+                   class="rounded-2xl bg-surface-container-high px-4 py-2 font-semibold text-primary">다음</a>
+            {% else %}
+                <span class="rounded-2xl bg-surface-container-high px-4 py-2 text-on-surface-variant">다음</span>
+            {% endif %}
+        </div>
+    {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- add search, filter, and pagination controls to the admin ingestion source, document, and job panels
- preserve per-panel HTMX refresh and query state while paginating or filtering
- add admin console coverage for ingestion filtering and pagination

## Testing
- python manage.py test apps.core.tests.test_admin_console --keepdb
- pre-commit run --all-files