### PR TITLE
feat: refine admin refresh interactions

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -67,6 +67,25 @@ h6 {
   animation: flash-exit 220ms ease-in forwards;
 }
 
+@keyframes admin-refresh-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+[data-admin-refresh-button].is-refreshing [data-admin-refresh-icon-static] {
+  opacity: 0;
+}
+
+[data-admin-refresh-button].is-refreshing [data-admin-refresh-icon-spinner] {
+  opacity: 1;
+  animation: admin-refresh-spin 720ms linear infinite;
+}
+
 .js-timezone-pending .timezone-sensitive {
   visibility: hidden;
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,3 +1,5 @@
+const ADMIN_REFRESH_SPIN_DURATION_MS = 720;
+
 document.body.addEventListener("htmx:afterSwap", (event) => {
   const target = event.detail.target;
   if (target && target.id) {
@@ -10,6 +12,48 @@ document.body.addEventListener("htmx:afterSwap", (event) => {
   initializeCodeCopyButtons(root);
   initializeProfileImageUploader(root);
   renderMath(target || document.body);
+});
+
+window.startAdminRefreshAnimation = function startAdminRefreshAnimation(button) {
+  if (!(button instanceof HTMLElement)) {
+    return;
+  }
+  window.clearTimeout(Number(button.dataset.refreshStopTimer || 0));
+  button.classList.remove("is-refreshing");
+  // Force a reflow so repeat clicks restart the spin immediately.
+  void button.offsetWidth;
+  button.dataset.refreshStartedAt = String(Date.now());
+  button.classList.add("is-refreshing");
+};
+
+window.stopAdminRefreshAnimation = function stopAdminRefreshAnimation() {
+  document.querySelectorAll("[data-admin-refresh-button].is-refreshing").forEach((button) => {
+    if (!(button instanceof HTMLElement)) {
+      return;
+    }
+    const startedAt = Number(button.dataset.refreshStartedAt || 0);
+    const elapsed = startedAt ? Date.now() - startedAt : ADMIN_REFRESH_SPIN_DURATION_MS;
+    const progressInCurrentSpin = elapsed % ADMIN_REFRESH_SPIN_DURATION_MS;
+    const remaining =
+      progressInCurrentSpin === 0
+        ? 0
+        : ADMIN_REFRESH_SPIN_DURATION_MS - progressInCurrentSpin;
+    window.clearTimeout(Number(button.dataset.refreshStopTimer || 0));
+    const timerId = window.setTimeout(() => {
+      button.classList.remove("is-refreshing");
+      delete button.dataset.refreshStartedAt;
+      delete button.dataset.refreshStopTimer;
+    }, remaining);
+    button.dataset.refreshStopTimer = String(timerId);
+  });
+};
+
+document.body.addEventListener("htmx:afterRequest", () => {
+  window.stopAdminRefreshAnimation();
+});
+
+document.body.addEventListener("htmx:responseError", () => {
+  window.stopAdminRefreshAnimation();
 });
 
 function closeAdminModal() {

--- a/templates/partials/admin/ingestion_documents_panel.html
+++ b/templates/partials/admin/ingestion_documents_panel.html
@@ -7,7 +7,7 @@
           hx-target="#admin-ingestion-documents"
           hx-swap="outerHTML"
           hx-push-url="true"
-          class="grid gap-3 rounded-[1.5rem] bg-white p-4 lg:grid-cols-[minmax(0,1.2fr)_180px] xl:grid-cols-[minmax(0,1.2fr)_180px_180px_auto]">
+          class="space-y-3 rounded-[1.5rem] bg-white p-4">
         <input type="hidden" name="section" value="recent_documents">
         <input type="hidden" name="source_query" value="{{ source_query }}">
         <input type="hidden"
@@ -24,25 +24,27 @@
                name="document_query"
                value="{{ document_query }}"
                placeholder="문서 제목, URL, 소스 검색"
-               class="min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant focus:ring-2 focus:ring-primary-container">
-        <select name="document_fetch_status"
-                class="min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface focus:ring-2 focus:ring-primary-container">
-            {% for value, label in document_fetch_status_choices %}
-                <option value="{{ value }}"
-                        {% if selected_document_fetch_status == value %}selected{% endif %}>{{ label }}</option>
-            {% endfor %}
-        </select>
-        <select name="document_wiki_status"
-                class="min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface focus:ring-2 focus:ring-primary-container">
-            {% for value, label in document_wiki_status_choices %}
-                <option value="{{ value }}"
-                        {% if selected_document_wiki_status == value %}selected{% endif %}>{{ label }}</option>
-            {% endfor %}
-        </select>
-        <button type="submit"
-                class="whitespace-nowrap rounded-2xl bg-primary-container px-4 py-3 text-sm font-semibold text-on-primary-container">
-            적용
-        </button>
+               class="w-full min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant focus:ring-2 focus:ring-primary-container">
+        <div class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+            <select name="document_fetch_status"
+                    class="w-full min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface focus:ring-2 focus:ring-primary-container">
+                {% for value, label in document_fetch_status_choices %}
+                    <option value="{{ value }}"
+                            {% if selected_document_fetch_status == value %}selected{% endif %}>{{ label }}</option>
+                {% endfor %}
+            </select>
+            <select name="document_wiki_status"
+                    class="w-full min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface focus:ring-2 focus:ring-primary-container">
+                {% for value, label in document_wiki_status_choices %}
+                    <option value="{{ value }}"
+                            {% if selected_document_wiki_status == value %}selected{% endif %}>{{ label }}</option>
+                {% endfor %}
+            </select>
+            <button type="submit"
+                    class="whitespace-nowrap rounded-2xl bg-primary-container px-4 py-3 text-sm font-semibold text-on-primary-container">
+                적용
+            </button>
+        </div>
     </form>
     <div class="space-y-3">
         {% for document in recent_documents %}

--- a/templates/partials/admin/ingestion_jobs_panel.html
+++ b/templates/partials/admin/ingestion_jobs_panel.html
@@ -7,7 +7,7 @@
           hx-target="#admin-ingestion-jobs"
           hx-swap="outerHTML"
           hx-push-url="true"
-          class="grid gap-3 rounded-[1.5rem] bg-white p-4 lg:grid-cols-[minmax(0,1.2fr)_220px_auto]">
+          class="space-y-3 rounded-[1.5rem] bg-white p-4">
         <input type="hidden" name="section" value="recent_jobs">
         <input type="hidden" name="source_query" value="{{ source_query }}">
         <input type="hidden"
@@ -31,18 +31,20 @@
                name="job_query"
                value="{{ job_query }}"
                placeholder="문서 제목, URL, 에러 메시지 검색"
-               class="min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant focus:ring-2 focus:ring-primary-container">
-        <select name="job_status"
-                class="min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface focus:ring-2 focus:ring-primary-container">
-            {% for value, label in job_status_choices %}
-                <option value="{{ value }}"
-                        {% if selected_job_status == value %}selected{% endif %}>{{ label }}</option>
-            {% endfor %}
-        </select>
-        <button type="submit"
-                class="whitespace-nowrap rounded-2xl bg-primary-container px-4 py-3 text-sm font-semibold text-on-primary-container lg:justify-self-start">
-            적용
-        </button>
+               class="w-full min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant focus:ring-2 focus:ring-primary-container">
+        <div class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
+            <select name="job_status"
+                    class="w-full min-w-0 rounded-2xl border-0 bg-surface-container-low px-4 py-3 text-sm text-on-surface focus:ring-2 focus:ring-primary-container">
+                {% for value, label in job_status_choices %}
+                    <option value="{{ value }}"
+                            {% if selected_job_status == value %}selected{% endif %}>{{ label }}</option>
+                {% endfor %}
+            </select>
+            <button type="submit"
+                    class="whitespace-nowrap rounded-2xl bg-primary-container px-4 py-3 text-sm font-semibold text-on-primary-container">
+                적용
+            </button>
+        </div>
     </form>
     <div class="space-y-3">
         {% for job in recent_jobs %}

--- a/templates/partials/section_header.html
+++ b/templates/partials/section_header.html
@@ -13,22 +13,39 @@
             <button type="button"
                     hx-get="{{ refresh_url }}{% if refresh_query %}?{{ refresh_query }}&{% else %}?section={{ refresh_section }}{% endif %}{% if refresh_query %}section={{ refresh_section }}{% endif %}"
                     hx-target="{{ refresh_target }}"
-                    hx-swap="outerHTML"
+                    hx-swap="outerHTML swap:240ms"
+                    data-admin-refresh-button
+                    onclick="window.startAdminRefreshAnimation?.(this)"
                     aria-label="섹션 새로고침"
                     title="새로고침"
                     class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-surface-container-high text-on-surface-variant transition hover:bg-surface-container-highest">
                 <span class="sr-only">새로고침</span>
-                <svg class="h-5 w-5"
-                     viewBox="0 0 24 24"
-                     fill="none"
-                     stroke="currentColor"
-                     stroke-width="2"
-                     stroke-linecap="round"
-                     stroke-linejoin="round"
-                     aria-hidden="true">
-                    <path d="M21 12a9 9 0 1 1-2.64-6.36" />
-                    <path d="M21 3v6h-6" />
-                </svg>
+                <span class="relative inline-flex h-5 w-5 items-center justify-center">
+                    <svg class="h-5 w-5 transition-opacity duration-150"
+                         data-admin-refresh-icon-static
+                         viewBox="0 0 24 24"
+                         fill="none"
+                         stroke="currentColor"
+                         stroke-width="2"
+                         stroke-linecap="round"
+                         stroke-linejoin="round"
+                         aria-hidden="true">
+                        <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+                        <path d="M21 3v6h-6" />
+                    </svg>
+                    <svg class="absolute inset-0 h-5 w-5 opacity-0 transition-opacity duration-150"
+                         data-admin-refresh-icon-spinner
+                         viewBox="0 0 24 24"
+                         fill="none"
+                         stroke="currentColor"
+                         stroke-width="2"
+                         stroke-linecap="round"
+                         stroke-linejoin="round"
+                         aria-hidden="true">
+                        <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+                        <path d="M21 3v6h-6" />
+                    </svg>
+                </span>
             </button>
         {% endif %}
         {% if href and link_text %}


### PR DESCRIPTION
## Summary
- refine admin refresh button behavior and visuals
- adjust ingestion document/job filter layouts to use full-width search rows
- keep the current refresh interaction approach after tuning the UI details

## Testing
- nix develop --command python manage.py test apps.core.tests.test_admin_console --keepdb
- nix develop --command pre-commit run --files static/js/app.js static/css/app.css templates/partials/section_header.html templates/partials/admin/ingestion_documents_panel.html templates/partials/admin/ingestion_jobs_panel.html