### PR TITLE
Feat/slack build notifications

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -24,3 +24,4 @@ jobs:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## 개요

merge 이후 실행되는 이미지 빌드/스캔 결과를 빠르게 확인할 수 있도록 Slack 알림 기능을 추가했습니다.

기존에는 reusable image workflow가 PR 화면에 직접 드러나지 않아, merge 후 Actions 탭에 직접 들어가 결과를 확인해야 했습니다.
이번 변경으로 build / scan / push 성공 여부를 Slack 채널에서 즉시 확인할 수 있습니다.

## 변경 사항

* reusable image workflow에 Slack 알림 step 추가
* GitHub Actions job 상태(success/failure) 기반 메시지 분기
* `if: always()` 적용으로 중간 실패 시에도 알림 전송
* Slack Incoming Webhook 기반 구현
* GitHub Actions run 링크 포함
* repository / branch / image / tag / actor 정보 포함
* caller workflow에서 `SLACK_WEBHOOK_URL` secret 전달 추가

## 기대 효과

* merge 이후 이미지 빌드 실패 즉시 인지 가능
* Trivy 보안 스캔 실패 여부를 팀 전체가 빠르게 확인 가능
* Actions 탭 수동 확인 감소
* build pipeline 가시성 향상
