### PR TITLE
docs: add Prometheus and Grafana observability guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,25 @@ OAuth callback URL은 현재 요청의 host/scheme를 기준으로 서버에서 
 
 HTTP 메트릭의 `route` 라벨은 가능한 경우 raw path 대신 Django route pattern 기준으로 집계해 path parameter로 인한 cardinality 증가를 줄입니다.
 
+### Prometheus / Grafana 구성 가이드
+
+이 저장소에는 아래 예시 파일이 포함되어 있습니다.
+
+- `docs/observability/prometheus-scrape.example.yml`
+- `docs/observability/grafana-dashboard-hivewiki-overview.json`
+- `docs/observability/README.md`
+
+경우별 운영 원칙은 아래와 같습니다.
+
+- 단일 인스턴스 또는 단일 컨테이너
+  `GET /metrics/`를 해당 인스턴스 주소로 직접 scrape 하면 됩니다.
+- Kubernetes에서 Pod가 여러 개
+  외부 LB나 Ingress 주소 하나를 scrape하지 말고, Prometheus가 각 Pod endpoint를 개별 target으로 발견하도록 설정해야 합니다.
+- 한 Pod 안에 worker 프로세스가 여러 개
+  `PROMETHEUS_MULTIPROC_DIR`를 설정해 Pod 내부 프로세스 메트릭도 합산해야 합니다.
+
+여러 Pod 메트릭의 "클러스터 전체 집계"는 애플리케이션이 직접 하는 것이 아니라 Prometheus 쿼리에서 수행합니다. 예를 들어 전체 요청량은 `sum(rate(hivewiki_http_requests_total[5m]))`처럼 계산합니다.
+
 ## 배포 시 권장값
 
 배포 환경에서는 최소한 아래 값들을 권장합니다.

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,203 @@
+# Observability
+
+이 애플리케이션은 `GET /metrics/`에서 Prometheus 형식 메트릭을 노출합니다.
+
+기본 메트릭:
+
+- `hivewiki_up`
+- `hivewiki_process_start_time_seconds`
+- `hivewiki_build_info`
+- `hivewiki_readiness_check{check="database|cache"}`
+- `hivewiki_ready`
+- `hivewiki_http_requests_total{method,route}`
+- `hivewiki_http_responses_total{method,route,status_code}`
+- `hivewiki_http_request_duration_seconds_bucket{method,route,le}`
+- `hivewiki_http_request_duration_seconds_sum{method,route}`
+- `hivewiki_http_request_duration_seconds_count{method,route}`
+
+## 경우별 구성
+
+### 1. 단일 인스턴스 또는 단일 컨테이너
+
+애플리케이션 주소를 직접 scrape 하면 됩니다.
+
+예시:
+
+```yaml
+scrape_configs:
+  - job_name: hivewiki-web
+    metrics_path: /metrics/
+    scrape_interval: 15s
+    scrape_timeout: 5s
+    static_configs:
+      - targets:
+          - app.example.com
+    scheme: https
+```
+
+이 경우 Prometheus는 한 target만 scrape 합니다.
+
+### 2. Kubernetes에서 여러 Pod를 띄우는 경우
+
+Prometheus가 각 Pod를 개별 target으로 scrape 해야 합니다. 외부 Load Balancer나 Ingress 주소 하나만 scrape 하면 Pod별 상태와 집계가 정확하지 않을 수 있습니다.
+
+권장 방식:
+
+1. 앱 Pod를 선택하는 `Service`를 만든다.
+2. Prometheus에서 `kubernetes_sd_configs`를 사용해 해당 Service의 endpoints를 발견한다.
+3. Grafana/PromQL에서는 `sum`, `max`, `min`으로 Pod 결과를 집계한다.
+
+Service 예시:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hivewiki-web-metrics
+  namespace: hivewiki
+  labels:
+    app: hivewiki-web
+spec:
+  selector:
+    app: hivewiki-web
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+```
+
+Prometheus `scrape_configs` 예시:
+
+```yaml
+scrape_configs:
+  - job_name: hivewiki-web
+    metrics_path: /metrics/
+    scrape_interval: 15s
+    scrape_timeout: 5s
+
+    kubernetes_sd_configs:
+      - role: endpoints
+
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace]
+        regex: hivewiki
+        action: keep
+
+      - source_labels: [__meta_kubernetes_service_name]
+        regex: hivewiki-web-metrics
+        action: keep
+
+      - source_labels: [__meta_kubernetes_endpoint_port_name]
+        regex: http
+        action: keep
+
+      - source_labels: [__meta_kubernetes_pod_name]
+        target_label: pod
+
+      - source_labels: [__meta_kubernetes_namespace]
+        target_label: namespace
+
+      - source_labels: [__meta_kubernetes_service_name]
+        target_label: service
+```
+
+정상 동작 확인:
+
+- Prometheus UI의 `Status > Targets`에서 Pod 수만큼 target이 보여야 합니다.
+- target이 하나만 보이면 외부 LB/Ingress 하나만 scrape하고 있을 가능성이 큽니다.
+
+### 3. 한 Pod 안에 worker 프로세스가 여러 개인 경우
+
+예를 들어 Gunicorn worker 여러 개를 쓰면, Pod 내부 프로세스별 메트릭을 multiprocess 모드로 합쳐야 합니다.
+
+이 애플리케이션은 `PROMETHEUS_MULTIPROC_DIR`가 설정되면 multiprocess registry를 사용합니다.
+
+운영 원칙:
+
+1. Pod 안에서 worker들이 공용으로 쓰는 writable 디렉터리를 준비한다.
+2. `PROMETHEUS_MULTIPROC_DIR`를 그 경로로 설정한다.
+3. Pod 시작 시 이전 실행의 multiprocess 파일을 정리한다.
+
+주의:
+
+- 이 설정은 "Pod 내부 프로세스 합산"용입니다.
+- "여러 Pod 간 합산"은 Prometheus가 각 Pod를 scrape한 뒤 쿼리에서 집계합니다.
+
+## 집계 쿼리 예시
+
+### 전체 요청량
+
+```promql
+sum(rate(hivewiki_http_requests_total{job="hivewiki-web"}[5m]))
+```
+
+### 전체 5xx 응답량
+
+```promql
+sum(rate(hivewiki_http_responses_total{job="hivewiki-web",status_code=~"5.."}[5m]))
+```
+
+### 전체 latency p95
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le) (
+    rate(hivewiki_http_request_duration_seconds_bucket{job="hivewiki-web"}[5m])
+  )
+)
+```
+
+### Pod별 요청량
+
+```promql
+sum by (pod) (rate(hivewiki_http_requests_total{job="hivewiki-web"}[5m]))
+```
+
+### 모든 Pod가 ready인지 확인
+
+```promql
+min(hivewiki_ready{job="hivewiki-web"})
+```
+
+### Pod 중 하나라도 살아있는지 확인
+
+```promql
+max(hivewiki_up{job="hivewiki-web"})
+```
+
+## Grafana
+
+대시보드 템플릿은 `grafana-dashboard-hivewiki-overview.json`을 import 해서 사용할 수 있습니다.
+
+포함 내용:
+
+- 앱 up / ready 상태
+- 전체 요청량
+- 전체 5xx 비율
+- 전체 latency p95
+- route별 요청량
+- route별 latency p95
+- 상태 코드 분포
+- dependency readiness
+
+## 파일 목록
+
+- `prometheus-scrape.example.yml`: 단일 인스턴스 scrape 예시
+- `grafana-dashboard-hivewiki-overview.json`: Grafana import 템플릿
+- `k8s-service.metrics.example.yml`: Kubernetes Pod별 scrape용 Service 예시
+- `prometheus-kubernetes-scrape.example.yml`: plain Prometheus의 Kubernetes service discovery 예시
+
+## 배포 레포에 옮길 최소 조합
+
+Kubernetes에서 Pod별 scrape를 하려면 보통 아래 두 파일을 배포 레포로 옮기면 됩니다.
+
+1. `k8s-service.metrics.example.yml`
+2. `prometheus-kubernetes-scrape.example.yml`
+
+적용 순서:
+
+1. 앱 Pod를 선택하는 metrics 전용 `Service`를 배포한다.
+2. Prometheus `scrape_configs`에 `hivewiki-web` job을 추가한다.
+3. Prometheus UI `Status > Targets`에서 Pod 수만큼 target이 잡히는지 확인한다.
+4. Grafana에서 `grafana-dashboard-hivewiki-overview.json`을 import 한다.

--- a/docs/observability/grafana-dashboard-hivewiki-overview.json
+++ b/docs/observability/grafana-dashboard-hivewiki-overview.json
@@ -1,0 +1,1002 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(hivewiki_up{job=~\"$job\",instance=~\"$instance\"})",
+          "legendFormat": "up",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "App Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Not Ready"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Ready"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(hivewiki_ready{job=~\"$job\",instance=~\"$instance\"})",
+          "legendFormat": "ready",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "App Ready",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(hivewiki_http_requests_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "rps",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests/sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "100 * (sum(rate(hivewiki_http_responses_total{job=~\"$job\",instance=~\"$instance\",status_code=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(hivewiki_http_responses_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])), 1e-9))",
+          "legendFormat": "5xx %",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "5xx Error Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(hivewiki_http_request_duration_seconds_bucket{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Latency P95",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dtdurationms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "(time() - max(hivewiki_process_start_time_seconds{job=~\"$job\",instance=~\"$instance\"})) * 1000",
+          "legendFormat": "uptime",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Process Uptime",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (route) (rate(hivewiki_http_requests_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate by Route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (route, le) (rate(hivewiki_http_request_duration_seconds_bucket{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "{{route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Latency P95 by Route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 70,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (status_code) (rate(hivewiki_http_responses_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{status_code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Responses by Status Code",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 75,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "100 * (sum by (route) (rate(hivewiki_http_responses_total{job=~\"$job\",instance=~\"$instance\",status_code=~\"5..\"}[$__rate_interval])) / clamp_min(sum by (route) (rate(hivewiki_http_responses_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])), 1e-9))",
+          "legendFormat": "{{route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "5xx Rate by Route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 11,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (route) (rate(hivewiki_http_requests_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (route, le) (rate(hivewiki_http_request_duration_seconds_bucket{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{route}}",
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "100 * (sum by (route) (rate(hivewiki_http_responses_total{job=~\"$job\",instance=~\"$instance\",status_code=~\"5..\"}[$__rate_interval])) / clamp_min(sum by (route) (rate(hivewiki_http_responses_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])), 1e-9))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{route}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Route Summary",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value #A": false,
+              "Value #B": false,
+              "Value #C": false,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            },
+            "renameByName": {
+              "Value #A": "rps",
+              "Value #B": "p95_seconds",
+              "Value #C": "error_percent"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Fail"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "OK"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 12,
+      "options": {
+        "displayMode": "lcd",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max by (check) (hivewiki_readiness_check{job=~\"$job\",instance=~\"$instance\"})",
+          "legendFormat": "{{check}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Dependency Readiness",
+      "type": "bargauge"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "hivewiki",
+    "django",
+    "prometheus"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "hivewiki-web",
+          "value": "hivewiki-web"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(hivewiki_up, job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(hivewiki_up, job)",
+          "refId": "Prometheus-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(hivewiki_up{job=~\"$job\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(hivewiki_up{job=~\"$job\"}, instance)",
+          "refId": "Prometheus-instance-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "HiveWiki Overview",
+  "uid": "hivewiki-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/observability/k8s-service.metrics.example.yml
+++ b/docs/observability/k8s-service.metrics.example.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hivewiki-web-metrics
+  namespace: hivewiki
+  labels:
+    app: hivewiki-web
+spec:
+  selector:
+    app: hivewiki-web
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000

--- a/docs/observability/prometheus-kubernetes-scrape.example.yml
+++ b/docs/observability/prometheus-kubernetes-scrape.example.yml
@@ -1,0 +1,30 @@
+scrape_configs:
+  - job_name: hivewiki-web
+    metrics_path: /metrics/
+    scrape_interval: 15s
+    scrape_timeout: 5s
+
+    kubernetes_sd_configs:
+      - role: endpoints
+
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace]
+        regex: hivewiki
+        action: keep
+
+      - source_labels: [__meta_kubernetes_service_name]
+        regex: hivewiki-web-metrics
+        action: keep
+
+      - source_labels: [__meta_kubernetes_endpoint_port_name]
+        regex: http
+        action: keep
+
+      - source_labels: [__meta_kubernetes_pod_name]
+        target_label: pod
+
+      - source_labels: [__meta_kubernetes_namespace]
+        target_label: namespace
+
+      - source_labels: [__meta_kubernetes_service_name]
+        target_label: service

--- a/docs/observability/prometheus-scrape.example.yml
+++ b/docs/observability/prometheus-scrape.example.yml
@@ -1,0 +1,12 @@
+scrape_configs:
+  - job_name: hivewiki-web
+    metrics_path: /metrics/
+    scrape_interval: 15s
+    scrape_timeout: 5s
+    static_configs:
+      - targets:
+          - app.example.com
+    scheme: https
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: instance


### PR DESCRIPTION
## Summary
- add Prometheus and Grafana observability documentation
- add plain Prometheus Kubernetes scrape examples
- add a Grafana dashboard import template for HiveWiki metrics

## Testing
- pre-commit run --all-files