### PR TITLE
fix: bypass host validation for metrics scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Commit message는 **영어로 작성해야 하며**, Conventional Commits 규칙
   예: `HTTP_X_FORWARDED_PROTO,https`
 - `SESSION_COOKIE_AGE`: 세션 유지 시간. 초 단위
 
-`/livez/`, `/readyz/`, `/metrics/`는 인프라용 엔드포인트라 `DJANGO_SECURE_SSL_REDIRECT=True`여도 HTTPS redirect 예외로 처리됩니다. 다만 Kubernetes 등에서 내부 Service 주소로 scrape 하려면 `DJANGO_ALLOWED_HOSTS`에 해당 내부 host도 함께 포함해야 합니다.
+`/livez/`, `/readyz/`, `/metrics/`는 인프라용 엔드포인트라 `DJANGO_SECURE_SSL_REDIRECT=True`여도 HTTPS redirect 예외로 처리됩니다. 또한 `/metrics/`는 host validation 전에 처리되므로 Prometheus가 Pod IP 기반으로 scrape 하더라도 Django의 `ALLOWED_HOSTS` 검증에 막히지 않습니다.
 
 브라우저 timezone은 별도 엔드포인트 `POST /auth/timezone/`를 통해 세션 키 `django_timezone`에 저장됩니다. 이 값은 로그인/로그아웃 과정에서 세션이 재설정되어도 유지되며, 서버는 이를 사용해 사용자별 시간대를 활성화하고 클라이언트는 timezone-sensitive UI를 로컬 시간대로 다시 렌더링합니다.
 

--- a/config/healthchecks.py
+++ b/config/healthchecks.py
@@ -2,13 +2,14 @@ import ipaddress
 
 from django.conf import settings
 
-from config.observability import liveness_probe, readiness_probe
+from config.observability import liveness_probe, metrics_view, readiness_probe
 
 HEALTHCHECK_PATHS = frozenset(("/livez/", "/readyz/"))
 ELB_HEALTHCHECK_USER_AGENT_PREFIX = "ELB-HealthChecker/"
 HEALTHCHECK_VIEWS = {
     "/livez/": liveness_probe,
     "/readyz/": readiness_probe,
+    "/metrics/": metrics_view,
 }
 
 

--- a/config/tests/test_healthchecks.py
+++ b/config/tests/test_healthchecks.py
@@ -1,8 +1,10 @@
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, override_settings
 from django.urls import path
+from unittest.mock import patch
 
 from config.healthchecks import HealthcheckHostNormalizationMiddleware
+from config.observability import metrics_view
 
 
 def ok_view(_request):
@@ -11,6 +13,7 @@ def ok_view(_request):
 
 urlpatterns = [
     path("livez/", ok_view),
+    path("metrics/", metrics_view),
     path("dashboard/", ok_view),
 ]
 
@@ -64,3 +67,16 @@ class HealthcheckHostNormalizationMiddlewareTests(SimpleTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode(), "ok\n")
+
+    @patch("config.observability.run_readiness_checks")
+    def test_metrics_is_short_circuited_before_host_validation(
+        self, run_readiness_checks
+    ):
+        run_readiness_checks.return_value = {"database": True, "cache": True}
+
+        response = self.client.get(
+            "/metrics/",
+            HTTP_HOST="10.0.0.42:8000",
+        )
+
+        self.assertEqual(response.status_code, 200)

--- a/config/tests/test_healthchecks.py
+++ b/config/tests/test_healthchecks.py
@@ -1,7 +1,8 @@
+from unittest.mock import patch
+
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, override_settings
 from django.urls import path
-from unittest.mock import patch
 
 from config.healthchecks import HealthcheckHostNormalizationMiddleware
 from config.observability import metrics_view

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -41,7 +41,7 @@ scrape_configs:
 
 Prometheus가 각 Pod를 개별 target으로 scrape 해야 합니다. 외부 Load Balancer나 Ingress 주소 하나만 scrape 하면 Pod별 상태와 집계가 정확하지 않을 수 있습니다.
 
-이 애플리케이션은 `/metrics/`, `/livez/`, `/readyz/`를 HTTPS redirect 예외로 처리합니다. 대신 내부 Service DNS나 scrape host를 사용할 경우 해당 host가 `DJANGO_ALLOWED_HOSTS`에 포함되어 있어야 합니다.
+이 애플리케이션은 `/metrics/`, `/livez/`, `/readyz/`를 HTTPS redirect 예외로 처리합니다. 또한 `/metrics/`는 host validation 전에 처리되므로 Pod IP 기반 scrape도 가능합니다.
 
 권장 방식:
 


### PR DESCRIPTION
## Summary
- serve /metrics/ before Django host validation rejects pod IP based scraping
- keep /livez/ and /readyz/ behavior aligned with infrastructure endpoints
- document pod IP based Prometheus scraping behavior

## Testing
- nix develop --command python manage.py test config.tests.test_healthchecks config.tests.test_observability