### PR TITLE
fix: suppress metrics access logs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Commit message는 **영어로 작성해야 하며**, Conventional Commits 규칙
 - `DJANGO_X_FRAME_OPTIONS`: `X-Frame-Options` 값. 기본 `DENY`
 - `DJANGO_LOG_LEVEL`: 애플리케이션 로그 레벨. 기본 `INFO`
 - `DJANGO_LOG_JSON`: JSON 구조화 로그 사용 여부. 기본 `True`
-- `DJANGO_LOG_HEALTHCHECKS`: `/livez/`, `/readyz/` access 로그 출력 여부. 기본 `False`
+- `DJANGO_LOG_HEALTHCHECKS`: `/livez/`, `/readyz/`, `/metrics/` access 로그 출력 여부. 기본 `False`
 - `DJANGO_SECURE_PROXY_SSL_HEADER`: 프록시 뒤에서 HTTPS 판별에 사용할 헤더
   예: `HTTP_X_FORWARDED_PROTO,https`
 - `SESSION_COOKIE_AGE`: 세션 유지 시간. 초 단위

--- a/config/logging.py
+++ b/config/logging.py
@@ -17,7 +17,7 @@ _request_context: contextvars.ContextVar[dict[str, object] | None] = (
         default=None,
     )
 )
-HEALTHCHECK_PATHS = frozenset(("/livez/", "/readyz/"))
+OBSERVABILITY_PATHS = frozenset(("/livez/", "/readyz/", "/metrics/"))
 ACCESS_LOGGER_NAMES = frozenset(("django.server", "hivewiki.request", "uvicorn.access"))
 
 
@@ -42,11 +42,11 @@ def _normalize_path(path: str | None) -> str:
     return normalized_path
 
 
-def is_healthcheck_path(path: str | None) -> bool:
-    return _normalize_path(path) in HEALTHCHECK_PATHS
+def is_observability_path(path: str | None) -> bool:
+    return _normalize_path(path) in OBSERVABILITY_PATHS
 
 
-def should_log_healthcheck_requests() -> bool:
+def should_log_observability_requests() -> bool:
     return getattr(settings, "DJANGO_LOG_HEALTHCHECKS", False)
 
 
@@ -69,14 +69,14 @@ class RequestContextFilter(logging.Filter):
 
 class SuppressHealthcheckAccessLogsFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
-        if should_log_healthcheck_requests():
+        if should_log_observability_requests():
             return True
 
         if record.name not in ACCESS_LOGGER_NAMES:
             return True
 
         path = self._get_path(record)
-        if not is_healthcheck_path(path):
+        if not is_observability_path(path):
             return True
 
         if record.name == "hivewiki.request":
@@ -216,7 +216,7 @@ class RequestLoggingMiddleware:
             status_code=response.status_code,
             duration_seconds=duration_seconds,
         )
-        if should_log_healthcheck_requests() or not is_healthcheck_path(
+        if should_log_observability_requests() or not is_observability_path(
             request.path_info
         ):
             self.logger.info("request_complete")

--- a/config/tests/test_logging_filters.py
+++ b/config/tests/test_logging_filters.py
@@ -51,6 +51,19 @@ class SuppressHealthcheckAccessLogsFilterTests(SimpleTestCase):
 
         self.assertFalse(self.filter.filter(record))
 
+    def test_suppresses_uvicorn_access_log_for_metrics(self):
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg='%s - "%s %s HTTP/%s" %d',
+            args=("127.0.0.1:54321", "GET", "/metrics/", "1.1", 200),
+            exc_info=None,
+        )
+
+        self.assertFalse(self.filter.filter(record))
+
     def test_suppresses_django_server_access_log_for_healthcheck(self):
         record = logging.LogRecord(
             name="django.server",
@@ -86,6 +99,20 @@ class SuppressHealthcheckAccessLogsFilterTests(SimpleTestCase):
             lineno=1,
             msg='%s - "%s %s HTTP/%s" %d',
             args=("127.0.0.1:54321", "GET", "/livez/", "1.1", 200),
+            exc_info=None,
+        )
+
+        self.assertTrue(self.filter.filter(record))
+
+    @override_settings(DJANGO_LOG_HEALTHCHECKS=True)
+    def test_can_enable_metrics_access_logs(self):
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg='%s - "%s %s HTTP/%s" %d',
+            args=("127.0.0.1:54321", "GET", "/metrics/", "1.1", 200),
             exc_info=None,
         )
 

--- a/config/tests/test_request_logging.py
+++ b/config/tests/test_request_logging.py
@@ -3,8 +3,6 @@ from django.http import HttpResponse, StreamingHttpResponse
 from django.test import AsyncClient, SimpleTestCase, override_settings
 from django.urls import path
 
-from config.logging import RequestLoggingMiddleware
-
 
 async def async_request_id_view(request):
     return HttpResponse(request.request_id, content_type="text/plain")

--- a/config/tests/test_request_logging.py
+++ b/config/tests/test_request_logging.py
@@ -1,12 +1,9 @@
-from unittest.mock import patch
-
 from asgiref.sync import async_to_sync
 from django.http import HttpResponse, StreamingHttpResponse
 from django.test import AsyncClient, SimpleTestCase, override_settings
 from django.urls import path
 
 from config.logging import RequestLoggingMiddleware
-from config.observability import liveness_probe
 
 
 async def async_request_id_view(request):
@@ -20,7 +17,6 @@ def streaming_request_id_view(request):
 urlpatterns = [
     path("async-request-id/", async_request_id_view),
     path("streaming-request-id/", streaming_request_id_view),
-    path("livez/", liveness_probe),
 ]
 
 
@@ -41,19 +37,3 @@ class RequestLoggingMiddlewareTests(SimpleTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(b"".join(response.streaming_content).decode(), request_id)
-
-    def test_healthcheck_path_skips_request_complete_log_by_default(self):
-        with patch.object(RequestLoggingMiddleware.logger, "info") as logger_info:
-            response = self.client.get("/livez/")
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("X-Request-ID", response.headers)
-        logger_info.assert_not_called()
-
-    @override_settings(DJANGO_LOG_HEALTHCHECKS=True)
-    def test_healthcheck_path_logs_when_enabled(self):
-        with patch.object(RequestLoggingMiddleware.logger, "info") as logger_info:
-            response = self.client.get("/livez/")
-
-        self.assertEqual(response.status_code, 200)
-        logger_info.assert_called_once_with("request_complete")


### PR DESCRIPTION
## Summary
- treat /metrics/ like other observability endpoints in access log suppression
- keep metrics access logs behind the existing DJANGO_LOG_HEALTHCHECKS toggle
- update request logging tests and README wording

## Testing
- nix develop --command python manage.py test config.tests.test_request_logging config.tests.test_logging_filters