### PR TITLE
feat: add related wiki recommendations

### DIFF
--- a/apps/core/markdown_rendering.py
+++ b/apps/core/markdown_rendering.py
@@ -31,6 +31,7 @@ ALLOWED_TAGS = [
     "pre",
     "span",
     "strong",
+    "sup",
     "table",
     "tbody",
     "td",
@@ -50,6 +51,7 @@ ALLOWED_ATTRIBUTES = {
 }
 REVISION_RENDER_CACHE_TIMEOUT = 60 * 60 * 24 * 7
 CODE_NODE_RE = re.compile(r"<code\b[^>]*>.*?</code>", re.DOTALL)
+INLINE_SOURCE_RE = re.compile(r"출처:\s*\[([^\]]+)\]\(([^)\s]+)\)")
 
 
 def build_rendered_markdown(
@@ -99,6 +101,7 @@ def build_rendered_markdown(
 def get_cached_revision_render(*, revision, title: str) -> dict[str, object]:
     if revision is None:
         return {
+            "citations": [],
             "display_markdown": "",
             "rendered_markdown": "",
             "toc_items": [],
@@ -110,8 +113,10 @@ def get_cached_revision_render(*, revision, title: str) -> dict[str, object]:
         return cached_value
 
     display_markdown = strip_leading_title_heading(revision.content_markdown, title)
+    display_markdown, citations = _extract_inline_citations(display_markdown)
     rendered_markdown, toc_items = build_rendered_markdown(display_markdown)
     payload = {
+        "citations": citations,
         "display_markdown": display_markdown,
         "rendered_markdown": rendered_markdown,
         "toc_items": toc_items,
@@ -142,3 +147,32 @@ def _restore_code_node_entities(match: re.Match[str]) -> str:
         .replace("&amp;#39;", "&#39;")
         .replace("&amp;amp;", "&amp;")
     )
+
+
+def _extract_inline_citations(
+    markdown_text: str,
+) -> tuple[str, list[dict[str, str | int]]]:
+    if not markdown_text:
+        return "", []
+
+    citations: list[dict[str, str | int]] = []
+    citation_numbers: dict[tuple[str, str], int] = {}
+
+    def replace(match: re.Match[str]) -> str:
+        title, url = match.groups()
+        key = (title.strip(), url.strip())
+        number = citation_numbers.get(key)
+        if number is None:
+            number = len(citations) + 1
+            citation_numbers[key] = number
+            citations.append(
+                {
+                    "index": number,
+                    "title": key[0],
+                    "url": key[1],
+                }
+            )
+        return f'<sup class="wiki-citation-marker">[{number}]</sup>'
+
+    cleaned_markdown = INLINE_SOURCE_RE.sub(replace, markdown_text)
+    return cleaned_markdown, citations

--- a/apps/core/search.py
+++ b/apps/core/search.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from .models import Post, PostStatus, WikiDocument, WikiDocumentStatus
 
 
-def get_wiki_search_results(*, query="", limit=12):
+def get_wiki_search_queryset(*, query=""):
     documents = (
         WikiDocument.objects.filter(
             status=WikiDocumentStatus.PUBLISHED,
@@ -43,6 +43,12 @@ def get_wiki_search_results(*, query="", limit=12):
                 | Q(summary__icontains=normalized_query)
                 | Q(current_revision__content_markdown__icontains=normalized_query)
             )
+    return documents
+
+
+def get_wiki_search_results(*, query="", limit=12):
+    normalized_query = query.strip()
+    documents = get_wiki_search_queryset(query=query)
 
     total_count = documents.count()
     documents = list(documents[:limit])

--- a/apps/core/tests/test_search_views.py
+++ b/apps/core/tests/test_search_views.py
@@ -215,6 +215,63 @@ class SearchViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'value="회고"', html=False)
 
+    def test_wiki_home_paginates_full_page_results(self):
+        for index in range(9):
+            document = WikiDocument.objects.create(
+                title=f"운영 문서 {index}",
+                slug=f"ops-doc-{index}",
+                summary="페이지네이션 확인용 문서입니다.",
+                status=WikiDocumentStatus.PUBLISHED,
+                updated_at=timezone.now() + timezone.timedelta(minutes=index),
+            )
+            revision = WikiRevision.objects.create(
+                wiki_document=document,
+                revision_number=1,
+                content_markdown="## 운영 문서",
+                generation_type=WikiGenerationType.AI,
+                generation_model="gpt-5.5",
+            )
+            document.current_revision = revision
+            document.save(update_fields=["current_revision"])
+
+        response = self.client.get("/wiki/", {"page": 2})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "페이지 2 / 2")
+        self.assertContains(response, "운영 문서 0")
+        self.assertNotContains(response, "운영 문서 8")
+
+    def test_wiki_home_paginates_htmx_results_with_query(self):
+        for index in range(9):
+            document = WikiDocument.objects.create(
+                title=f"회고 문서 {index}",
+                slug=f"retro-doc-{index}",
+                summary="회고 검색 결과입니다.",
+                status=WikiDocumentStatus.PUBLISHED,
+                updated_at=timezone.now() + timezone.timedelta(minutes=index),
+            )
+            revision = WikiRevision.objects.create(
+                wiki_document=document,
+                revision_number=1,
+                content_markdown="## 회고 항목",
+                generation_type=WikiGenerationType.AI,
+                generation_model="gpt-5.5",
+            )
+            document.current_revision = revision
+            document.save(update_fields=["current_revision"])
+
+        response = self.client.get(
+            "/wiki/",
+            {"q": "회고", "page": 2},
+            headers={"HX-Request": "true"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "페이지 2 / 2")
+        self.assertContains(response, 'hx-get="/wiki/?q=%ED%9A%8C%EA%B3%A0"')
+        self.assertContains(response, "회고 문서 0")
+        self.assertNotContains(response, "회고 문서 8")
+
     def test_integrated_search_returns_empty_state_for_blank_htmx_query(self):
         response = self.client.get(
             "/search/",

--- a/apps/core/tests/test_wiki_views.py
+++ b/apps/core/tests/test_wiki_views.py
@@ -3,10 +3,15 @@ from django.urls import reverse
 from django.utils import timezone
 
 from apps.core.models import (
+    ChunkEmbedding,
+    Source,
+    SourceChunk,
+    SourceDocument,
     WikiDocument,
     WikiDocumentStatus,
     WikiGenerationType,
     WikiRevision,
+    WikiRevisionSource,
 )
 
 
@@ -28,6 +33,10 @@ from apps.core.models import (
     },
 )
 class WikiViewTests(TestCase):
+    @staticmethod
+    def _embedding(first_value, second_value):
+        return [first_value] * 768 + [second_value] * 768
+
     def test_wiki_home_links_to_detail_page(self):
         document = WikiDocument.objects.create(
             title="캡스톤 위키 운영 가이드",
@@ -93,6 +102,268 @@ class WikiViewTests(TestCase):
         self.assertContains(response, 'data-copy-success-text="링크 복사됨!"')
         self.assertContains(response, 'id="human-copy"')
         self.assertNotContains(response, 'style="')
+
+    def test_wiki_detail_formats_inline_sources_as_citations(self):
+        document = WikiDocument.objects.create(
+            title="수강신청 변경 안내",
+            slug="course-change-guide",
+            summary="수강신청 변경 기간 안내 문서입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        revision = WikiRevision.objects.create(
+            wiki_document=document,
+            revision_number=1,
+            content_markdown=(
+                "수강신청 변경은 2026년 3월 3일 오전 10시부터 3월 9일 오후 3시까지 진행된다"
+                "출처: [2026학년도 1학기 수강신청 변경 기간 안내](https://example.com/course-change).\n\n"
+                "휴학생은 신청이 불가능하다"
+                "출처: [2026학년도 1학기 수강신청 변경 기간 안내](https://example.com/course-change)."
+            ),
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        document.current_revision = revision
+        document.save(update_fields=["current_revision"])
+
+        response = self.client.get("/wiki/course-change-guide/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            '<sup class="wiki-citation-marker">[1]</sup>',
+            html=True,
+        )
+        self.assertContains(response, "참고 출처")
+        self.assertContains(response, "2026학년도 1학기 수강신청 변경 기간 안내")
+        self.assertContains(response, "https://example.com/course-change")
+
+    def test_wiki_detail_shows_related_wiki_documents(self):
+        source = Source.objects.create(
+            name="학사 공지",
+            target_url="https://example.com/notices",
+        )
+        source_document = SourceDocument.objects.create(
+            source=source,
+            canonical_url="https://example.com/notices/course-change",
+            title="수강신청 변경 안내 원문",
+            body_text="수강신청 변경과 복수전공 신청 안내",
+        )
+        shared_chunk = SourceChunk.objects.create(
+            source_document=source_document,
+            chunk_index=0,
+            content_text="수강신청 변경 일정과 복수전공 신청 절차",
+        )
+
+        primary_document = WikiDocument.objects.create(
+            title="수강신청 변경 안내",
+            slug="course-change-guide",
+            summary="수강신청 변경 기간 안내 문서입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        primary_revision = WikiRevision.objects.create(
+            wiki_document=primary_document,
+            revision_number=1,
+            content_markdown="## 수강신청 변경",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        primary_document.current_revision = primary_revision
+        primary_document.save(update_fields=["current_revision"])
+        WikiRevisionSource.objects.create(
+            wiki_revision=primary_revision,
+            source_chunk=shared_chunk,
+            evidence_text=shared_chunk.content_text,
+        )
+
+        related_document = WikiDocument.objects.create(
+            title="복수전공 신청 안내",
+            slug="double-major-guide",
+            summary="복수전공 신청 절차 문서입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now() + timezone.timedelta(minutes=1),
+        )
+        related_revision = WikiRevision.objects.create(
+            wiki_document=related_document,
+            revision_number=1,
+            content_markdown="## 복수전공 신청",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        related_document.current_revision = related_revision
+        related_document.save(update_fields=["current_revision"])
+        WikiRevisionSource.objects.create(
+            wiki_revision=related_revision,
+            source_chunk=shared_chunk,
+            evidence_text=shared_chunk.content_text,
+        )
+
+        unrelated_document = WikiDocument.objects.create(
+            title="기숙사 입사 안내",
+            slug="dormitory-guide",
+            summary="기숙사 입사 절차 문서입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now() - timezone.timedelta(days=1),
+        )
+        unrelated_revision = WikiRevision.objects.create(
+            wiki_document=unrelated_document,
+            revision_number=1,
+            content_markdown="## 기숙사 입사",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        unrelated_document.current_revision = unrelated_revision
+        unrelated_document.save(update_fields=["current_revision"])
+
+        response = self.client.get("/wiki/course-change-guide/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "연관 위키")
+        self.assertContains(response, "복수전공 신청 안내")
+        self.assertEqual(
+            response.context["related_wiki_items"][0]["title"],
+            "복수전공 신청 안내",
+        )
+
+    def test_wiki_detail_prioritizes_embedding_similar_documents(self):
+        primary_source = Source.objects.create(
+            name="학사 공지",
+            target_url="https://example.com/notices",
+        )
+        primary_source_document = SourceDocument.objects.create(
+            source=primary_source,
+            canonical_url="https://example.com/notices/course-change",
+            title="수강신청 변경 안내 원문",
+            body_text="수강신청 변경 일정",
+        )
+        primary_chunk = SourceChunk.objects.create(
+            source_document=primary_source_document,
+            chunk_index=0,
+            content_text="수강신청 변경 일정",
+        )
+        ChunkEmbedding.objects.create(
+            source_chunk=primary_chunk,
+            embedding_model="text-embedding-3-small",
+            embedding_dim=1536,
+            embedding=self._embedding(1.0, 0.0),
+        )
+
+        primary_document = WikiDocument.objects.create(
+            title="수강신청 변경 안내",
+            slug="course-change-guide",
+            summary="수강신청 변경 기간 안내 문서입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        primary_revision = WikiRevision.objects.create(
+            wiki_document=primary_document,
+            revision_number=1,
+            content_markdown="## 수강신청 변경",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        primary_document.current_revision = primary_revision
+        primary_document.save(update_fields=["current_revision"])
+        WikiRevisionSource.objects.create(
+            wiki_revision=primary_revision,
+            source_chunk=primary_chunk,
+            evidence_text=primary_chunk.content_text,
+        )
+
+        similar_source = Source.objects.create(
+            name="유사 문서 소스",
+            target_url="https://example.com/similar",
+        )
+        similar_source_document = SourceDocument.objects.create(
+            source=similar_source,
+            canonical_url="https://example.com/similar/double-major",
+            title="복수전공 신청 안내 원문",
+            body_text="복수전공 신청 일정",
+        )
+        similar_chunk = SourceChunk.objects.create(
+            source_document=similar_source_document,
+            chunk_index=0,
+            content_text="복수전공 신청 일정",
+        )
+        ChunkEmbedding.objects.create(
+            source_chunk=similar_chunk,
+            embedding_model="text-embedding-3-small",
+            embedding_dim=1536,
+            embedding=self._embedding(0.9, 0.1),
+        )
+        similar_document = WikiDocument.objects.create(
+            title="복수전공 신청 안내",
+            slug="double-major-guide",
+            summary="복수전공 신청 절차 문서입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now(),
+        )
+        similar_revision = WikiRevision.objects.create(
+            wiki_document=similar_document,
+            revision_number=1,
+            content_markdown="## 복수전공 신청",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        similar_document.current_revision = similar_revision
+        similar_document.save(update_fields=["current_revision"])
+        WikiRevisionSource.objects.create(
+            wiki_revision=similar_revision,
+            source_chunk=similar_chunk,
+            evidence_text=similar_chunk.content_text,
+        )
+
+        dissimilar_source = Source.objects.create(
+            name="비유사 문서 소스",
+            target_url="https://example.com/dissimilar",
+        )
+        dissimilar_source_document = SourceDocument.objects.create(
+            source=dissimilar_source,
+            canonical_url="https://example.com/dissimilar/dormitory",
+            title="기숙사 입사 안내 원문",
+            body_text="기숙사 입사 절차",
+        )
+        dissimilar_chunk = SourceChunk.objects.create(
+            source_document=dissimilar_source_document,
+            chunk_index=0,
+            content_text="기숙사 입사 절차",
+        )
+        ChunkEmbedding.objects.create(
+            source_chunk=dissimilar_chunk,
+            embedding_model="text-embedding-3-small",
+            embedding_dim=1536,
+            embedding=self._embedding(0.0, 1.0),
+        )
+        dissimilar_document = WikiDocument.objects.create(
+            title="기숙사 입사 안내",
+            slug="dormitory-guide",
+            summary="기숙사 입사 절차 문서입니다.",
+            status=WikiDocumentStatus.PUBLISHED,
+            updated_at=timezone.now() + timezone.timedelta(minutes=3),
+        )
+        dissimilar_revision = WikiRevision.objects.create(
+            wiki_document=dissimilar_document,
+            revision_number=1,
+            content_markdown="## 기숙사 입사",
+            generation_type=WikiGenerationType.AI,
+            generation_model="gpt-5.5",
+        )
+        dissimilar_document.current_revision = dissimilar_revision
+        dissimilar_document.save(update_fields=["current_revision"])
+        WikiRevisionSource.objects.create(
+            wiki_revision=dissimilar_revision,
+            source_chunk=dissimilar_chunk,
+            evidence_text=dissimilar_chunk.content_text,
+        )
+
+        response = self.client.get("/wiki/course-change-guide/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context["related_wiki_items"][0]["title"],
+            "복수전공 신청 안내",
+        )
 
     def test_wiki_detail_adds_safe_rel_to_links(self):
         document = WikiDocument.objects.create(

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import re
 from urllib.parse import urlencode
 
@@ -25,6 +26,7 @@ from .community_content import extract_linked_wiki_slugs
 from .forms import CommentForm, PostForm, SourceForm, TagForm
 from .markdown_rendering import get_cached_revision_render
 from .models import (
+    ChunkEmbedding,
     Comment,
     CommentLike,
     IngestionJob,
@@ -41,8 +43,13 @@ from .models import (
     WikiBookmark,
     WikiDocument,
     WikiDocumentStatus,
+    WikiRevisionSource,
 )
-from .search import get_post_search_results, get_wiki_search_results
+from .search import (
+    get_post_search_results,
+    get_wiki_search_queryset,
+    get_wiki_search_results,
+)
 from .wiki_markdown import strip_leading_title_heading
 
 logger = logging.getLogger(__name__)
@@ -52,6 +59,7 @@ ADMIN_CONTENT_WIKI_PAGE_SIZE = 6
 ADMIN_INGESTION_SOURCE_PAGE_SIZE = 6
 ADMIN_INGESTION_DOCUMENT_PAGE_SIZE = 8
 ADMIN_INGESTION_JOB_PAGE_SIZE = 8
+WIKI_HOME_PAGE_SIZE = 8
 
 ADMIN_USER_ACTIONS = frozenset(
     {
@@ -581,13 +589,27 @@ def community_wiki_picker(request):
 
 def wiki_home(request):
     query = request.GET.get("q", "").strip()
-    search_results = get_wiki_search_results(query=query, limit=8)
+    page_number = request.GET.get("page", "1").strip() or "1"
+    wiki_queryset = get_wiki_search_queryset(query=query)
+    paginator = Paginator(wiki_queryset, WIKI_HOME_PAGE_SIZE)
+    page_obj = paginator.get_page(page_number)
     context = {
         "page_heading": "Wiki",
         "list_tags": LIST_TAGS,
         "query": query,
-        "wiki_items": search_results["items"],
-        "wiki_result_count": search_results["total_count"],
+        "wiki_items": _build_wiki_card_items(page_obj.object_list),
+        "wiki_result_count": paginator.count,
+        "page_obj": page_obj,
+        "wiki_prev_url": (
+            _build_wiki_home_url(query=query, page=page_obj.previous_page_number())
+            if page_obj.has_previous()
+            else ""
+        ),
+        "wiki_next_url": (
+            _build_wiki_home_url(query=query, page=page_obj.next_page_number())
+            if page_obj.has_next()
+            else ""
+        ),
         "hide_topbar_search": True,
     }
     if request.headers.get("HX-Request") == "true":
@@ -645,6 +667,7 @@ def wiki_detail(request, slug):
     featured_wiki_documents.extend(
         list(wiki_document_queryset.exclude(pk=document.pk)[:5])
     )
+    related_wiki_documents = _get_related_wiki_documents(document, limit=4)
     selected_wiki_document_ids = [
         str(document_id)
         for document_id in (compose_post_form["wiki_documents"].value() or [])
@@ -685,6 +708,7 @@ def wiki_detail(request, slug):
             "query": "",
             "display_markdown": rendered_revision["display_markdown"],
             "rendered_markdown": rendered_revision["rendered_markdown"],
+            "citations": rendered_revision["citations"],
             "toc_items": rendered_revision["toc_items"],
             "share_url": share_url,
             "copy_human_text": _build_human_copy(document, revision, share_url),
@@ -705,6 +729,7 @@ def wiki_detail(request, slug):
             "selected_wiki_document_ids": selected_wiki_document_ids,
             "selected_wiki_documents": selected_wiki_documents,
             "locked_wiki_document_ids": [str(document.pk)],
+            "related_wiki_items": _build_wiki_card_items(related_wiki_documents),
             "compose_wiki_search_url": reverse("community_wiki_picker"),
             "tag_options": list(_community_tag_queryset()[:12]),
             "compose_tag_options": list(_community_tag_queryset()[:40]),
@@ -997,6 +1022,220 @@ def _build_wiki_card_items(documents):
         }
         for document in documents
     ]
+
+
+def _get_related_wiki_documents(document, *, limit=4):
+    if document.current_revision_id is None or limit <= 0:
+        return []
+
+    source_document_ids = list(
+        WikiRevisionSource.objects.filter(
+            wiki_revision_id=document.current_revision_id
+        ).values_list("source_chunk__source_document_id", flat=True)
+    )
+    related_documents: list[WikiDocument] = []
+    seen_document_ids = {document.pk}
+    base_queryset = _community_wiki_document_queryset().exclude(pk=document.pk)
+    embedding_model = _get_document_embedding_model(document)
+
+    if embedding_model:
+        embedding_related_documents = _get_embedding_related_wiki_documents(
+            document=document,
+            source_document_ids=source_document_ids,
+            embedding_model=embedding_model,
+            limit=limit,
+        )
+        related_documents.extend(embedding_related_documents)
+        seen_document_ids.update(
+            related_document.pk for related_document in embedding_related_documents
+        )
+
+    if len(related_documents) < limit and source_document_ids:
+        source_related_documents = list(
+            base_queryset.exclude(pk__in=seen_document_ids)
+            .annotate(
+                shared_source_document_count=Count(
+                    "current_revision__sources__source_chunk__source_document",
+                    filter=Q(
+                        current_revision__sources__source_chunk__source_document_id__in=source_document_ids
+                    ),
+                    distinct=True,
+                )
+            )
+            .filter(shared_source_document_count__gt=0)
+            .order_by("-shared_source_document_count", "-updated_at", "title")[
+                : limit - len(related_documents)
+            ]
+        )
+        related_documents.extend(source_related_documents)
+        seen_document_ids.update(
+            related_document.pk for related_document in source_related_documents
+        )
+
+    if len(related_documents) < limit:
+        fallback_documents = list(
+            base_queryset.exclude(pk__in=seen_document_ids).order_by(
+                "-updated_at", "title"
+            )[: limit - len(related_documents)]
+        )
+        related_documents.extend(fallback_documents)
+
+    return related_documents
+
+
+def _get_embedding_related_wiki_documents(
+    *, document, source_document_ids, embedding_model: str, limit: int
+):
+    current_vector = _get_document_embedding_centroid(
+        document,
+        embedding_model=embedding_model,
+    )
+    if current_vector is None:
+        return []
+
+    candidate_documents = list(
+        _community_wiki_document_queryset()
+        .exclude(pk=document.pk)
+        .filter(
+            current_revision__sources__source_chunk__embeddings__embedding_model=embedding_model
+        )
+        .select_related("current_revision")
+        .prefetch_related(
+            "current_revision__sources__source_chunk__embeddings",
+            "current_revision__sources__source_chunk",
+        )
+        .distinct()
+    )
+    scored_documents = []
+    source_document_id_set = set(source_document_ids)
+    for candidate_document in candidate_documents:
+        candidate_vector = _get_document_embedding_centroid(
+            candidate_document,
+            embedding_model=embedding_model,
+        )
+        if candidate_vector is None:
+            continue
+        similarity = _cosine_similarity(current_vector, candidate_vector)
+        if similarity is None:
+            continue
+        candidate_source_document_ids = _get_document_source_document_ids(
+            candidate_document
+        )
+        shared_source_document_count = len(
+            source_document_id_set.intersection(candidate_source_document_ids)
+        )
+        scored_documents.append(
+            (
+                shared_source_document_count,
+                similarity,
+                candidate_document.updated_at,
+                candidate_document,
+            )
+        )
+
+    scored_documents.sort(
+        key=lambda item: (
+            -item[0],
+            -item[1],
+            -item[2].timestamp(),
+            item[3].title,
+        )
+    )
+    return [item[3] for item in scored_documents[:limit]]
+
+
+def _get_document_embedding_model(document):
+    if document.current_revision_id is None:
+        return None
+    return (
+        ChunkEmbedding.objects.filter(
+            source_chunk__wiki_revision_sources__wiki_revision_id=document.current_revision_id
+        )
+        .order_by("embedding_model", "created_at")
+        .values_list("embedding_model", flat=True)
+        .first()
+    )
+
+
+def _get_document_embedding_centroid(document, *, embedding_model: str):
+    if document.current_revision_id is None:
+        return None
+
+    vectors = []
+    seen_chunk_ids = set()
+    for revision_source in document.current_revision.sources.all():
+        source_chunk = revision_source.source_chunk
+        if source_chunk.pk in seen_chunk_ids:
+            continue
+        seen_chunk_ids.add(source_chunk.pk)
+        embedding = next(
+            (
+                chunk_embedding
+                for chunk_embedding in source_chunk.embeddings.all()
+                if chunk_embedding.embedding_model == embedding_model
+            ),
+            None,
+        )
+        if embedding is None:
+            continue
+        parsed_vector = _parse_embedding_vector(embedding.embedding)
+        if parsed_vector is None:
+            continue
+        vectors.append(parsed_vector)
+
+    if not vectors:
+        return None
+
+    dimension = len(vectors[0])
+    centroid = [0.0] * dimension
+    for vector in vectors:
+        if len(vector) != dimension:
+            continue
+        for index, value in enumerate(vector):
+            centroid[index] += value
+    vector_count = len(vectors)
+    return [value / vector_count for value in centroid]
+
+
+def _get_document_source_document_ids(document):
+    if document.current_revision_id is None:
+        return set()
+    return {
+        revision_source.source_chunk.source_document_id
+        for revision_source in document.current_revision.sources.all()
+    }
+
+
+def _parse_embedding_vector(value):
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        return [float(item) for item in value]
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        if stripped[0] == "[" and stripped[-1] == "]":
+            stripped = stripped[1:-1]
+        if not stripped:
+            return None
+        return [float(item.strip()) for item in stripped.split(",") if item.strip()]
+    return None
+
+
+def _cosine_similarity(left_vector, right_vector):
+    if not left_vector or not right_vector or len(left_vector) != len(right_vector):
+        return None
+    numerator = 0.0
+    left_norm = 0.0
+    right_norm = 0.0
+    for left_value, right_value in zip(left_vector, right_vector, strict=True):
+        numerator += left_value * right_value
+        left_norm += left_value * left_value
+        right_norm += right_value * right_value
+    if left_norm <= 0 or right_norm <= 0:
+        return None
+    return numerator / (math.sqrt(left_norm) * math.sqrt(right_norm))
 
 
 def _get_selected_wiki_documents(selected_wiki_document_ids):
@@ -1472,6 +1711,18 @@ def _build_community_feed_url(*, page, selected_tag_slug=""):
     if selected_tag_slug:
         params["tag"] = selected_tag_slug
     return f"{reverse('community_list')}?{urlencode(params)}"
+
+
+def _build_wiki_home_url(*, query="", page=1):
+    params = {}
+    if query:
+        params["q"] = query
+    if page and int(page) > 1:
+        params["page"] = page
+    querystring = urlencode(params)
+    return (
+        f"{reverse('wiki_home')}?{querystring}" if querystring else reverse("wiki_home")
+    )
 
 
 def _build_community_list_url(

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -253,6 +253,29 @@ h6 {
   text-align: left;
 }
 
+.reading-prose .wiki-citation-marker {
+  margin-left: 0.18rem;
+  color: var(--primary);
+  font-size: 0.78em;
+  font-weight: 800;
+  line-height: 1;
+  vertical-align: super;
+}
+
+.wiki-citation-pill {
+  display: inline-flex;
+  min-width: 2rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--primary-container) 70%, white);
+  color: var(--on-primary-container);
+  font-size: 0.9rem;
+  font-weight: 800;
+  line-height: 1;
+  padding: 0.45rem 0.55rem;
+}
+
 .wiki-actions-panel {
   position: relative;
 }

--- a/templates/pages/wiki/detail.html
+++ b/templates/pages/wiki/detail.html
@@ -91,6 +91,52 @@
                     <article class="reading-prose prose prose-stone mt-8 max-w-none leading-8 text-on-surface">
                         {{ rendered_markdown|safe }}
                     </article>
+                    {% if citations %}
+                        <section class="mt-8 border-t border-outline-variant/70 pt-6">
+                            <div class="flex flex-wrap items-center justify-between gap-3">
+                                <div>
+                                    <h2 class="font-headline text-2xl font-extrabold tracking-tight text-on-surface">참고 출처</h2>
+                                    <p class="mt-1 text-sm text-on-surface-variant">본문의 출처 표기를 읽기 쉬운 목록으로 정리했습니다.</p>
+                                </div>
+                                <div class="rounded-full bg-surface-container-high px-4 py-2 text-sm font-semibold text-on-surface-variant">
+                                    {{ citations|length }}건
+                                </div>
+                            </div>
+                            <ol class="mt-5 space-y-3">
+                                {% for citation in citations %}
+                                    <li class="rounded-[1.25rem] bg-white/80 px-5 py-4 shadow-sm ring-1 ring-outline-variant/50">
+                                        <div class="flex items-start gap-4">
+                                            <span class="wiki-citation-pill">{{ citation.index }}</span>
+                                            <div class="min-w-0 flex-1">
+                                                <div class="font-semibold text-on-surface">{{ citation.title }}</div>
+                                                <a href="{{ citation.url }}"
+                                                   class="mt-2 block break-all text-sm text-primary underline decoration-primary/40 underline-offset-2 transition hover:text-primary/80"
+                                                   rel="noopener noreferrer">{{ citation.url }}</a>
+                                            </div>
+                                        </div>
+                                    </li>
+                                {% endfor %}
+                            </ol>
+                        </section>
+                    {% endif %}
+                    {% if related_wiki_items %}
+                        <section class="mt-8 border-t border-outline-variant/70 pt-6">
+                            <div class="flex flex-wrap items-center justify-between gap-3">
+                                <div>
+                                    <h2 class="font-headline text-2xl font-extrabold tracking-tight text-on-surface">연관 위키</h2>
+                                    <p class="mt-1 text-sm text-on-surface-variant">같은 출처를 공유하거나 최근 함께 참고할 만한 문서를 모았습니다.</p>
+                                </div>
+                                <div class="rounded-full bg-surface-container-high px-4 py-2 text-sm font-semibold text-on-surface-variant">
+                                    {{ related_wiki_items|length }}건
+                                </div>
+                            </div>
+                            <div class="mt-5 grid gap-4 xl:grid-cols-2">
+                                {% for item in related_wiki_items %}
+                                    {% include "partials/wiki_card.html" %}
+                                {% endfor %}
+                            </div>
+                        </section>
+                    {% endif %}
                 {% else %}
                     {% include "partials/empty_state.html" with title="표시할 리비전이 없습니다" description="현재 문서에 연결된 최신 리비전이 없습니다." %}
                 {% endif %}

--- a/templates/partials/wiki_search_results.html
+++ b/templates/partials/wiki_search_results.html
@@ -19,6 +19,31 @@
                 {% include "partials/wiki_card.html" %}
             {% endfor %}
         </div>
+        {% if page_obj.paginator.num_pages > 1 %}
+            <div class="flex items-center justify-between gap-4 rounded-[1.5rem] bg-surface-container-high px-5 py-4">
+                <div class="text-sm text-on-surface-variant">페이지 {{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</div>
+                <div class="flex items-center gap-3">
+                    {% if page_obj.has_previous %}
+                        <a href="{{ wiki_prev_url }}"
+                           hx-get="{{ wiki_prev_url }}"
+                           hx-target="#wiki-search-results"
+                           hx-swap="innerHTML"
+                           class="rounded-full bg-white px-4 py-2 text-sm font-semibold text-on-surface transition hover:-translate-y-0.5 hover:bg-surface">
+                            이전
+                        </a>
+                    {% endif %}
+                    {% if page_obj.has_next %}
+                        <a href="{{ wiki_next_url }}"
+                           hx-get="{{ wiki_next_url }}"
+                           hx-target="#wiki-search-results"
+                           hx-swap="innerHTML"
+                           class="rounded-full bg-white px-4 py-2 text-sm font-semibold text-on-surface transition hover:-translate-y-0.5 hover:bg-surface">
+                            다음
+                        </a>
+                    {% endif %}
+                </div>
+            </div>
+        {% endif %}
     {% else %}
         {% include "partials/empty_state.html" with title="문서를 찾지 못했습니다" description="다른 키워드나 더 짧은 검색어로 다시 시도해 보세요." %}
     {% endif %}


### PR DESCRIPTION
## Summary
- add related wiki recommendations on wiki detail pages
- rank related wiki documents using aggregated source chunk embeddings with source-sharing fallback
- add pagination to wiki search results for full-page and htmx requests
- format inline source mentions into citation markers with a dedicated references section

## Testing
- nix develop --command python manage.py test --keepdb --noinput apps.core.tests.test_wiki_views apps.core.tests.test_search_views