### PR TITLE
fix: keep footer at page bottom

### DIFF
--- a/templates/layouts/app.html
+++ b/templates/layouts/app.html
@@ -2,9 +2,9 @@
 {% block body %}
     <div class="min-h-screen bg-surface">
         {% include "partials/sidebar.html" %}
-        <div class="lg:ml-72">
+        <div class="flex min-h-screen flex-col lg:ml-72">
             {% include "partials/topbar.html" %}
-            <main class="px-6 pb-12 pt-28 lg:px-10">
+            <main class="flex-1 px-6 pb-12 pt-28 lg:px-10">
                 {% block app_content %}
                 {% endblock app_content %}
             </main>

--- a/templates/layouts/auth.html
+++ b/templates/layouts/auth.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block body %}
-    <div class="min-h-screen bg-surface">
-        <div class="grid lg:min-h-[calc(100vh-17rem)] lg:grid-cols-[1.05fr_0.95fr]">
+    <div class="flex min-h-screen flex-col bg-surface">
+        <div class="grid flex-1 lg:min-h-0 lg:grid-cols-[1.05fr_0.95fr]">
             <section class="relative hidden overflow-hidden bg-stone-950 px-10 py-12 text-stone-100 lg:flex">
                 <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,193,7,0.3),_transparent_32%),radial-gradient(circle_at_bottom_right,_rgba(255,255,255,0.09),_transparent_30%)]">
                 </div>


### PR DESCRIPTION
## Summary
- keep the auth layout content area stretched so the footer stays at the viewport bottom
- keep the main app layout content wrapper stretched so short pages do not leave the footer floating mid-screen

## Testing
- nix develop --command pre-commit run --all-files