### PR TITLE
fix(community): handle image upload credential failures

### DIFF
--- a/apps/accounts/services.py
+++ b/apps/accounts/services.py
@@ -18,6 +18,8 @@ import certifi
 from botocore.exceptions import (
     BotoCoreError,
     ClientError,
+    CredentialRetrievalError,
+    MetadataRetrievalError,
     NoCredentialsError,
     PartialCredentialsError,
 )
@@ -169,7 +171,13 @@ def build_public_image_upload_payload(
             ],
             ExpiresIn=600,
         )
-    except (NoCredentialsError, PartialCredentialsError, AttributeError) as exc:
+    except (
+        NoCredentialsError,
+        PartialCredentialsError,
+        CredentialRetrievalError,
+        MetadataRetrievalError,
+        AttributeError,
+    ) as exc:
         raise ProfileImageUploadError(
             "S3 업로드 자격 증명을 찾지 못했습니다. Pod Identity 또는 액세스 키 설정을 확인해 주세요."
         ) from exc

--- a/apps/core/tests/test_community_views.py
+++ b/apps/core/tests/test_community_views.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock, patch
 
-from botocore.exceptions import NoCredentialsError
+from botocore.exceptions import CredentialRetrievalError, NoCredentialsError
 from django.db import IntegrityError
 from django.test import TestCase, override_settings
 from django.utils import timezone
@@ -187,6 +187,28 @@ class CommunityViewTests(TestCase):
     ):
         mock_s3_client = Mock()
         mock_s3_client.generate_presigned_post.side_effect = NoCredentialsError()
+        mock_boto3_client.return_value = mock_s3_client
+
+        response = self.client.post(
+            "/community/image-upload/prepare/",
+            {"filename": "pasted-image.png", "content_type": "image/png"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["error"],
+            "S3 업로드 자격 증명을 찾지 못했습니다. Pod Identity 또는 액세스 키 설정을 확인해 주세요.",
+        )
+
+    @patch("apps.accounts.services.boto3.client")
+    def test_community_image_upload_prepare_returns_400_when_container_credentials_timeout(
+        self, mock_boto3_client
+    ):
+        mock_s3_client = Mock()
+        mock_s3_client.generate_presigned_post.side_effect = CredentialRetrievalError(
+            provider="container-role",
+            error_msg="metadata timeout",
+        )
         mock_boto3_client.return_value = mock_s3_client
 
         response = self.client.post(

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -524,6 +524,14 @@ function insertTextareaText(textarea, text) {
   textarea.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
+async function readJsonResponse(response) {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
 function initializeCommunityComposeImagePaste(root = document) {
   const forms =
     root instanceof Element
@@ -608,9 +616,12 @@ function initializeCommunityComposeImagePaste(root = document) {
         return;
       }
 
-      const prepareData = await prepareResponse.json();
+      const prepareData = await readJsonResponse(prepareResponse);
       if (!prepareResponse.ok) {
-        setStatus(prepareData.error || "업로드를 준비할 수 없습니다.", "error");
+        setStatus(
+          prepareData?.error || "업로드를 준비할 수 없습니다.",
+          "error",
+        );
         return;
       }
 


### PR DESCRIPTION
## Summary
- treat AWS container credential retrieval failures as upload credential errors
- return a user-facing upload error instead of a 500 from community image upload prepare
- guard the compose uploader against non-JSON error responses and add regression coverage

## Testing
- nix develop --command python manage.py test apps.core.tests.test_community_views --keepdb
