### PR TITLE
fix(core): normalize uploaded image html to markdown

### DIFF
--- a/apps/core/community_content.py
+++ b/apps/core/community_content.py
@@ -1,3 +1,4 @@
+import html
 import re
 
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)(?:\s+#+\s*)?$")
@@ -7,10 +8,12 @@ MARKDOWN_DECORATION_RE = re.compile(r"[*_~>#-]+")
 MULTISPACE_RE = re.compile(r"\s+")
 WIKI_LINK_RE = re.compile(r"/wiki/(?P<slug>[-\w]+)/")
 MARKDOWN_IMAGE_RE = re.compile(r"!\[[^\]]*]\((?P<url>[^)\s]+)(?:\s+\"[^\"]*\")?\)")
+HTML_IMAGE_RE = re.compile(r"<img\b[^>]*>", re.IGNORECASE)
+HTML_ATTR_RE = re.compile(r'(?P<name>[\w:-]+)\s*=\s*"(?P<value>[^"]*)"')
 
 
 def build_post_markdown(body_markdown: str) -> str:
-    cleaned_body = body_markdown.strip()
+    cleaned_body = _normalize_html_images(body_markdown).strip()
     if not cleaned_body:
         raise ValueError("게시글 본문은 비어 있을 수 없습니다.")
     return cleaned_body
@@ -87,9 +90,15 @@ def extract_first_image_url(content_markdown: str) -> str:
         return ""
 
     match = MARKDOWN_IMAGE_RE.search(content_markdown)
-    if not match:
+    if match:
+        return match.group("url").strip()
+
+    html_match = HTML_IMAGE_RE.search(content_markdown)
+    if not html_match:
         return ""
-    return match.group("url").strip()
+
+    attributes = _parse_html_attributes(html_match.group(0))
+    return attributes.get("src", "").strip()
 
 
 def _plain_text(value: str) -> str:
@@ -101,3 +110,25 @@ def _plain_text(value: str) -> str:
 
 def _normalize_line(value: str) -> str:
     return MULTISPACE_RE.sub(" ", value.strip())
+
+
+def _normalize_html_images(value: str) -> str:
+    if not value:
+        return ""
+    return HTML_IMAGE_RE.sub(_replace_html_image_with_markdown, value)
+
+
+def _replace_html_image_with_markdown(match: re.Match[str]) -> str:
+    attributes = _parse_html_attributes(match.group(0))
+    src = attributes.get("src", "").strip()
+    if not src:
+        return ""
+    alt = attributes.get("alt", "").strip()
+    return f"![{alt}]({src})"
+
+
+def _parse_html_attributes(tag: str) -> dict[str, str]:
+    return {
+        attr_match.group("name").lower(): html.unescape(attr_match.group("value"))
+        for attr_match in HTML_ATTR_RE.finditer(tag)
+    }

--- a/apps/core/tests/test_community_content.py
+++ b/apps/core/tests/test_community_content.py
@@ -5,6 +5,7 @@ from django.test import SimpleTestCase
 from apps.core.community_content import (
     build_post_excerpt,
     build_post_markdown,
+    extract_first_image_url,
     extract_post_render_parts,
     extract_post_title_and_body,
     strip_post_leading_title,
@@ -17,6 +18,16 @@ class CommunityContentTests(SimpleTestCase):
         markdown = build_post_markdown("첫 문단입니다.")
 
         self.assertEqual(markdown, "첫 문단입니다.")
+
+    def test_build_post_markdown_converts_html_image_to_markdown(self):
+        markdown = build_post_markdown(
+            '<img alt="대체텍스트" src="https://attachment.hive-wiki.com/community-images/tmp/example.png">'
+        )
+
+        self.assertEqual(
+            markdown,
+            "![대체텍스트](https://attachment.hive-wiki.com/community-images/tmp/example.png)",
+        )
 
     def test_extract_post_title_and_body_reads_leading_h1(self):
         title, body = extract_post_title_and_body(
@@ -80,3 +91,13 @@ class CommunityContentTests(SimpleTestCase):
             self.assertEqual(post.summary, "두 번째 요약")
 
         self.assertEqual(extract_parts.call_count, 2)
+
+    def test_extract_first_image_url_reads_html_image_for_legacy_content(self):
+        image_url = extract_first_image_url(
+            '<img alt="대체텍스트" src="https://attachment.hive-wiki.com/community-images/tmp/example.png">'
+        )
+
+        self.assertEqual(
+            image_url,
+            "https://attachment.hive-wiki.com/community-images/tmp/example.png",
+        )


### PR DESCRIPTION
## Summary
- normalize uploaded HTML img tags into markdown image syntax at save time
- preserve thumbnail extraction for legacy posts that still contain HTML img tags
- add regression coverage for markdown normalization and legacy image extraction

## Testing
- nix develop --command python manage.py test apps.core.tests.test_community_content --keepdb
