### PR TITLE
fix(core): allow markdown images to render

### DIFF
--- a/apps/core/markdown_rendering.py
+++ b/apps/core/markdown_rendering.py
@@ -24,6 +24,7 @@ ALLOWED_TAGS = [
     "h5",
     "h6",
     "hr",
+    "img",
     "input",
     "li",
     "ol",
@@ -47,6 +48,7 @@ ALLOWED_ATTRIBUTES = {
     "span": ["class"],
     "code": ["class"],
     "pre": ["class"],
+    "img": ["alt", "src", "title"],
     "input": ["checked", "disabled", "type"],
 }
 REVISION_RENDER_CACHE_TIMEOUT = 60 * 60 * 24 * 7

--- a/apps/core/tests/test_markdown_rendering.py
+++ b/apps/core/tests/test_markdown_rendering.py
@@ -1,0 +1,25 @@
+from django.test import SimpleTestCase
+
+from apps.core.markdown_rendering import build_rendered_markdown
+
+
+class MarkdownRenderingTests(SimpleTestCase):
+    def test_build_rendered_markdown_renders_markdown_images(self):
+        rendered_markdown, _ = build_rendered_markdown(
+            "![이미지](https://attachment.hive-wiki.com/community-images/tmp/example.png)"
+        )
+
+        self.assertIn("<img", rendered_markdown)
+        self.assertIn(
+            'src="https://attachment.hive-wiki.com/community-images/tmp/example.png"',
+            rendered_markdown,
+        )
+        self.assertIn('alt="이미지"', rendered_markdown)
+
+    def test_build_rendered_markdown_strips_unsafe_image_attributes(self):
+        rendered_markdown, _ = build_rendered_markdown(
+            '![이미지](https://attachment.hive-wiki.com/community-images/tmp/example.png){onclick="alert(1)"}'
+        )
+
+        self.assertIn("<img", rendered_markdown)
+        self.assertNotIn("onclick=", rendered_markdown)


### PR DESCRIPTION
## Summary
- allow img tags and safe image attributes in the markdown sanitizer
- keep markdown image rendering working after uploaded image normalization
- add regression coverage for markdown image rendering and unsafe attribute stripping

## Testing
- nix develop --command python manage.py test apps.core.tests.test_markdown_rendering apps.core.tests.test_community_content --keepdb
