### PR TITLE
fix(wiki): simplify citation backlinks

### DIFF
--- a/apps/core/markdown_rendering.py
+++ b/apps/core/markdown_rendering.py
@@ -170,11 +170,21 @@ def _extract_inline_citations(
             citations.append(
                 {
                     "index": number,
+                    "first_reference_id": f"wiki-citation-ref-{number}-1",
+                    "occurrence_count": 0,
                     "title": key[0],
                     "url": key[1],
                 }
             )
-        return f'<sup class="wiki-citation-marker">[{number}]</sup>'
+        citation = citations[number - 1]
+        citation["occurrence_count"] = int(citation["occurrence_count"]) + 1
+        occurrence = citation["occurrence_count"]
+        reference_id = f"wiki-citation-ref-{number}-{occurrence}"
+        return (
+            f'<sup class="wiki-citation-marker" id="{reference_id}">'
+            f'<a href="#wiki-citation-{number}" class="wiki-citation-link">[{number}]</a>'
+            "</sup>"
+        )
 
     cleaned_markdown = INLINE_SOURCE_RE.sub(replace, markdown_text)
     return cleaned_markdown, citations

--- a/apps/core/tests/test_wiki_views.py
+++ b/apps/core/tests/test_wiki_views.py
@@ -134,12 +134,15 @@ class WikiViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(
             response,
-            '<sup class="wiki-citation-marker">[1]</sup>',
-            html=True,
+            'id="wiki-citation-ref-1-1"',
         )
+        self.assertContains(response, 'href="#wiki-citation-1"')
+        self.assertContains(response, 'id="wiki-citation-1"')
         self.assertContains(response, "참고 출처")
         self.assertContains(response, "2026학년도 1학기 수강신청 변경 기간 안내")
         self.assertContains(response, "https://example.com/course-change")
+        self.assertContains(response, "본문으로")
+        self.assertNotContains(response, "인용 2회")
 
     def test_wiki_detail_shows_related_wiki_documents(self):
         source = Source.objects.create(

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -339,6 +339,15 @@ h6 {
   vertical-align: super;
 }
 
+.reading-prose .wiki-citation-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.reading-prose .wiki-citation-link:hover {
+  text-decoration: underline;
+}
+
 .wiki-citation-pill {
   display: inline-flex;
   min-width: 2rem;

--- a/templates/pages/wiki/detail.html
+++ b/templates/pages/wiki/detail.html
@@ -86,7 +86,8 @@
                             </div>
                             <ol class="mt-5 space-y-3">
                                 {% for citation in citations %}
-                                    <li class="rounded-[1.25rem] bg-white/80 px-5 py-4 shadow-sm ring-1 ring-outline-variant/50">
+                                    <li id="wiki-citation-{{ citation.index }}"
+                                        class="rounded-[1.25rem] bg-white/80 px-5 py-4 shadow-sm ring-1 ring-outline-variant/50">
                                         <div class="flex items-start gap-4">
                                             <span class="wiki-citation-pill">{{ citation.index }}</span>
                                             <div class="min-w-0 flex-1">
@@ -94,6 +95,14 @@
                                                    class="font-semibold text-on-surface underline decoration-primary/30 underline-offset-2 transition hover:text-primary"
                                                    rel="noopener noreferrer">{{ citation.title }}</a>
                                                 <div class="mt-2 break-all text-sm text-on-surface-variant">{{ citation.url }}</div>
+                                                <div class="mt-3 flex flex-wrap items-center gap-3 text-sm text-on-surface-variant">
+                                                    <a href="#{{ citation.first_reference_id }}"
+                                                       class="inline-flex items-center gap-1 font-semibold text-primary transition hover:text-primary/80"
+                                                       aria-label="본문 인용 위치로 돌아가기">
+                                                        <span aria-hidden="true">↩</span>
+                                                        <span>본문으로</span>
+                                                    </a>
+                                                </div>
                                             </div>
                                         </div>
                                     </li>


### PR DESCRIPTION
## Summary
- turn inline wiki citation markers into links back to the bibliography entries
- keep a single backlink from each bibliography entry to the first citation location
- remove repeated backlink clutter and the citation count label from the bibliography UI

## Testing
- nix develop --command python manage.py test apps.core.tests.test_wiki_views.WikiViewTests.test_wiki_detail_formats_inline_sources_as_citations --keepdb